### PR TITLE
Fix NumberFormatExceptions on parsing doubles from inputFields

### DIFF
--- a/src/main/java/org/semux/gui/SwingUtil.java
+++ b/src/main/java/org/semux/gui/SwingUtil.java
@@ -15,6 +15,7 @@ import java.awt.image.BufferedImage;
 import java.net.URL;
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
+import java.text.NumberFormat;
 import java.util.Comparator;
 import java.util.EnumMap;
 import java.util.Map;
@@ -23,6 +24,7 @@ import javax.swing.*;
 import javax.swing.table.DefaultTableCellRenderer;
 import javax.swing.table.TableColumnModel;
 import javax.swing.text.DefaultEditorKit;
+import javax.swing.text.NumberFormatter;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -178,15 +180,26 @@ public class SwingUtil {
         textfield.setComponentPopupMenu(popup);
         return textfield;
     }
-
-    public static String formatDouble(double value, String format) {
-        DecimalFormatSymbols dfs = new DecimalFormatSymbols();
-        dfs.setDecimalSeparator('.');
-        DecimalFormat decimalFormat = new DecimalFormat(format, dfs);
-        decimalFormat.setGroupingUsed(false);
-        return decimalFormat.format(value);
+    /**
+     * Generates a JFormattedTextfield which only allows long as entry 
+     * @return 
+     */
+    public static JFormattedTextField longFormattedTextField() {
+        NumberFormat format = NumberFormat.getInstance();
+        NumberFormatter formatter = new NumberFormatter(format);
+        formatter.setValueClass(Long.class);
+        formatter.setMinimum(0);
+        formatter.setMaximum(Long.MAX_VALUE);
+        formatter.setAllowsInvalid(false);
+        formatter.setCommitsOnValidEdit(true);
+        JFormattedTextField field = new JFormattedTextField(formatter);
+        return field;
     }
-    
+
+    /**
+     * Generates a JFormattedTextfield which only allows DoubleValues as entry 
+     * @return 
+     */
     public static JFormattedTextField doubleFormattedTextField() {
         DecimalFormatSymbols dfs = new DecimalFormatSymbols();
         dfs.setDecimalSeparator('.');
@@ -208,6 +221,21 @@ public class SwingUtil {
     }
 
     /**
+     * Formats a given double value correctly to String with given format
+     * 
+     * @param value 
+     * @param format
+     * @return
+     */
+    public static String formatDouble(double value, String format) {
+        DecimalFormatSymbols dfs = new DecimalFormatSymbols();
+        dfs.setDecimalSeparator('.');
+        DecimalFormat decimalFormat = new DecimalFormat(format, dfs);
+        decimalFormat.setGroupingUsed(false);
+        return decimalFormat.format(value);
+    }
+
+    /**
      * Integer number comparator.
      */
     public static final Comparator<Integer> INTEGER_COMPARATOR = (o1, o2) -> {
@@ -224,8 +252,7 @@ public class SwingUtil {
     /**
      * Number string comparator based on its value.<br />
      * 
-     * @exception throws
-     *                NumberFormatException
+     * @exception 
      */
     public static final Comparator<String> NUMBER_COMPARATOR = (o1, o2) -> {
         try {
@@ -239,8 +266,7 @@ public class SwingUtil {
     /**
      * Balance string comparator based on its value.<br />
      * 
-     * @exception throws
-     *                NumberFormatException
+     * @exception 
      */
     public static final Comparator<String> BALANCE_COMPARATOR = (o1, o2) -> {
         try {
@@ -255,8 +281,7 @@ public class SwingUtil {
     /**
      * Balance string comparator based on its value.<br />
      * 
-     * @exception throws
-     *                NumberFormatException
+     * @exception
      */
     public static final Comparator<String> PERCENTAGE_COMPARATOR = (o1, o2) -> {
         try {

--- a/src/main/java/org/semux/gui/SwingUtil.java
+++ b/src/main/java/org/semux/gui/SwingUtil.java
@@ -181,15 +181,15 @@ public class SwingUtil {
         return textfield;
     }
     /**
-     * Generates a JFormattedTextfield which only allows long as entry 
+     * Generates a JFormattedTextfield which only allows integer as entry 
      * @return 
      */
-    public static JFormattedTextField longFormattedTextField() {
+    public static JFormattedTextField integerFormattedTextField() {
         NumberFormat format = NumberFormat.getInstance();
         NumberFormatter formatter = new NumberFormatter(format);
-        formatter.setValueClass(Long.class);
+        formatter.setValueClass(Integer.class);
         formatter.setMinimum(0);
-        formatter.setMaximum(Long.MAX_VALUE);
+        formatter.setMaximum(Integer.MAX_VALUE);
         formatter.setAllowsInvalid(false);
         formatter.setCommitsOnValidEdit(true);
         JFormattedTextField field = new JFormattedTextField(formatter);

--- a/src/main/java/org/semux/gui/SwingUtil.java
+++ b/src/main/java/org/semux/gui/SwingUtil.java
@@ -194,7 +194,8 @@ public class SwingUtil {
     };
 
     /**
-     * Number string comparator based on its value.
+     * Number string comparator based on its value.<br />
+     * * @exception throws IllegalArgumentException on ParseException
      */
     public static final Comparator<String> NUMBER_COMPARATOR = (o1, o2) -> {
         try {
@@ -202,13 +203,14 @@ public class SwingUtil {
                     NumberFormat.getInstance().parse(o2).doubleValue());
         } catch (ParseException e) {
             logger.error("NumberFormatException", e);
+            throw new IllegalArgumentException(e);
         }
-        // we should never come here -> work or exception
-        return 0;
     };
 
     /**
-     * Balance string comparator based on its value.
+     * Balance string comparator based on its value.<br />
+     * 
+     * @exception throws IllegalArgumentException on ParseException
      */
     public static final Comparator<String> BALANCE_COMPARATOR = (o1, o2) -> {
 
@@ -217,13 +219,14 @@ public class SwingUtil {
                     NumberFormat.getInstance().parse(o2.substring(0, o2.length() - 4)).doubleValue());
         } catch (ParseException e) {
             logger.error("NumberFormatException", e);
+            throw new IllegalArgumentException(e);
         }
-        // we should never come here -> work or exception
-        return 0;
     };
 
     /**
-     * Balance string comparator based on its value.
+     * Balance string comparator based on its value.<br />
+     * 
+     * @exception throws IllegalArgumentException on ParseException
      */
     public static final Comparator<String> PERCENTAGE_COMPARATOR = (o1, o2) -> {
         try {
@@ -231,8 +234,7 @@ public class SwingUtil {
                     NumberFormat.getInstance().parse(o2.substring(0, o2.length() - 2)).doubleValue());
         } catch (ParseException e) {
             logger.error("NumberFormatException", e);
+            throw new IllegalArgumentException(e);
         }
-        // we should never come here -> work or exception
-        return 0;
     };
 }

--- a/src/main/java/org/semux/gui/SwingUtil.java
+++ b/src/main/java/org/semux/gui/SwingUtil.java
@@ -13,8 +13,8 @@ import java.awt.Image;
 import java.awt.Toolkit;
 import java.awt.image.BufferedImage;
 import java.net.URL;
-import java.text.NumberFormat;
-import java.text.ParseException;
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
 import java.util.Comparator;
 import java.util.EnumMap;
 import java.util.Map;
@@ -179,6 +179,34 @@ public class SwingUtil {
         return textfield;
     }
 
+    public static String formatDouble(double value, String format) {
+        DecimalFormatSymbols dfs = new DecimalFormatSymbols();
+        dfs.setDecimalSeparator('.');
+        DecimalFormat decimalFormat = new DecimalFormat(format, dfs);
+        decimalFormat.setGroupingUsed(false);
+        return decimalFormat.format(value);
+    }
+    
+    public static JFormattedTextField doubleFormattedTextField() {
+        DecimalFormatSymbols dfs = new DecimalFormatSymbols();
+        dfs.setDecimalSeparator('.');
+        DecimalFormat decimalFormat = new DecimalFormat("0.000", dfs);
+        decimalFormat.setGroupingUsed(false);
+        JFormattedTextField numberFormattedTextfield = new JFormattedTextField(decimalFormat);
+        JPopupMenu popup = new JPopupMenu();
+        JMenuItem item = new JMenuItem(new DefaultEditorKit.CutAction());
+        item.setText("Cut");
+        popup.add(item);
+        item = new JMenuItem(new DefaultEditorKit.CopyAction());
+        item.setText("Copy");
+        popup.add(item);
+        item = new JMenuItem(new DefaultEditorKit.PasteAction());
+        item.setText("Paste");
+        popup.add(item);
+        numberFormattedTextfield.setComponentPopupMenu(popup);
+        return numberFormattedTextfield;
+    }
+
     /**
      * Integer number comparator.
      */
@@ -195,29 +223,30 @@ public class SwingUtil {
 
     /**
      * Number string comparator based on its value.<br />
-     * @exception throws NumberFormatException on ParseException
+     * 
+     * @exception throws
+     *                NumberFormatException
      */
     public static final Comparator<String> NUMBER_COMPARATOR = (o1, o2) -> {
         try {
-            return Double.compare(NumberFormat.getInstance().parse(o1).doubleValue(),
-                    NumberFormat.getInstance().parse(o2).doubleValue());
-        } catch (ParseException e) {
+            return Double.compare(Double.parseDouble(o1), Double.parseDouble(o2));
+        } catch (NumberFormatException e) {
             logger.error("Wrong format or value for parsing to Double", e);
-            throw new NumberFormatException(e.getLocalizedMessage());
+            throw e;
         }
     };
 
     /**
      * Balance string comparator based on its value.<br />
      * 
-     * @exception throws NumberFormatException on ParseException
+     * @exception throws
+     *                NumberFormatException
      */
     public static final Comparator<String> BALANCE_COMPARATOR = (o1, o2) -> {
-
         try {
-            return Double.compare(NumberFormat.getInstance().parse(o1.substring(0, o1.length() - 4)).doubleValue(),
-                    NumberFormat.getInstance().parse(o2.substring(0, o2.length() - 4)).doubleValue());
-        } catch (ParseException e) {
+            return Double.compare(Double.parseDouble(o1.substring(0, o1.length() - 4).replaceAll(",", ".")),
+                    Double.parseDouble(o2.substring(0, o2.length() - 4).replaceAll(",", ".")));
+        } catch (NumberFormatException e) {
             logger.error("Wrong format or value for parsing to Double", e);
             throw new NumberFormatException(e.getLocalizedMessage());
         }
@@ -226,13 +255,14 @@ public class SwingUtil {
     /**
      * Balance string comparator based on its value.<br />
      * 
-     * @exception throws NumberFormatException on ParseException
+     * @exception throws
+     *                NumberFormatException
      */
     public static final Comparator<String> PERCENTAGE_COMPARATOR = (o1, o2) -> {
         try {
-            return Double.compare(NumberFormat.getInstance().parse(o1.substring(0, o1.length() - 2)).doubleValue(),
-                    NumberFormat.getInstance().parse(o2.substring(0, o2.length() - 2)).doubleValue());
-        } catch (ParseException e) {
+            return Double.compare(Double.parseDouble(o1.substring(0, o1.length() - 2).replaceAll(",", ".")),
+                    Double.parseDouble(o2.substring(0, o2.length() - 2).replaceAll(",", ".")));
+        } catch (NumberFormatException e) {
             logger.error("Wrong format or value for parsing to Double", e);
             throw new NumberFormatException(e.getLocalizedMessage());
         }

--- a/src/main/java/org/semux/gui/SwingUtil.java
+++ b/src/main/java/org/semux/gui/SwingUtil.java
@@ -13,6 +13,8 @@ import java.awt.Image;
 import java.awt.Toolkit;
 import java.awt.image.BufferedImage;
 import java.net.URL;
+import java.text.NumberFormat;
+import java.text.ParseException;
 import java.util.Comparator;
 import java.util.EnumMap;
 import java.util.Map;
@@ -195,22 +197,42 @@ public class SwingUtil {
      * Number string comparator based on its value.
      */
     public static final Comparator<String> NUMBER_COMPARATOR = (o1, o2) -> {
-        return Double.compare(Double.parseDouble(o1), Double.parseDouble(o2));
+        try {
+            return Double.compare(NumberFormat.getInstance().parse(o1).doubleValue(),
+                    NumberFormat.getInstance().parse(o2).doubleValue());
+        } catch (ParseException e) {
+            logger.error("NumberFormatException", e);
+        }
+        // we should never come here -> work or exception
+        return 0;
     };
 
     /**
      * Balance string comparator based on its value.
      */
     public static final Comparator<String> BALANCE_COMPARATOR = (o1, o2) -> {
-        return Double.compare(Double.parseDouble(o1.substring(0, o1.length() - 4)),
-                Double.parseDouble(o2.substring(0, o2.length() - 4)));
+
+        try {
+            return Double.compare(NumberFormat.getInstance().parse(o1.substring(0, o1.length() - 4)).doubleValue(),
+                    NumberFormat.getInstance().parse(o2.substring(0, o2.length() - 4)).doubleValue());
+        } catch (ParseException e) {
+            logger.error("NumberFormatException", e);
+        }
+        // we should never come here -> work or exception
+        return 0;
     };
 
     /**
      * Balance string comparator based on its value.
      */
     public static final Comparator<String> PERCENTAGE_COMPARATOR = (o1, o2) -> {
-        return Double.compare(Double.parseDouble(o1.substring(0, o1.length() - 2)),
-                Double.parseDouble(o2.substring(0, o2.length() - 2)));
+        try {
+            return Double.compare(NumberFormat.getInstance().parse(o1.substring(0, o1.length() - 2)).doubleValue(),
+                    NumberFormat.getInstance().parse(o2.substring(0, o2.length() - 2)).doubleValue());
+        } catch (ParseException e) {
+            logger.error("NumberFormatException", e);
+        }
+        // we should never come here -> work or exception
+        return 0;
     };
 }

--- a/src/main/java/org/semux/gui/SwingUtil.java
+++ b/src/main/java/org/semux/gui/SwingUtil.java
@@ -40,6 +40,8 @@ public class SwingUtil {
 
     private static final Logger logger = LoggerFactory.getLogger(SwingUtil.class);
 
+    public static final String DEFAULT_DOUBLE_FORMAT = "0.000";
+
     /**
      * Put a JFrame in the center of screen.
      * 
@@ -180,9 +182,11 @@ public class SwingUtil {
         textfield.setComponentPopupMenu(popup);
         return textfield;
     }
+
     /**
-     * Generates a JFormattedTextfield which only allows integer as entry 
-     * @return 
+     * Generates a JFormattedTextfield which only allows integer as entry
+     * 
+     * @return
      */
     public static JFormattedTextField integerFormattedTextField() {
         NumberFormat format = NumberFormat.getInstance();
@@ -197,13 +201,14 @@ public class SwingUtil {
     }
 
     /**
-     * Generates a JFormattedTextfield which only allows DoubleValues as entry 
-     * @return 
+     * Generates a JFormattedTextfield which only allows DoubleValues as entry
+     * 
+     * @return
      */
     public static JFormattedTextField doubleFormattedTextField() {
         DecimalFormatSymbols dfs = new DecimalFormatSymbols();
         dfs.setDecimalSeparator('.');
-        DecimalFormat decimalFormat = new DecimalFormat("0.000", dfs);
+        DecimalFormat decimalFormat = new DecimalFormat(SwingUtil.DEFAULT_DOUBLE_FORMAT, dfs);
         decimalFormat.setGroupingUsed(false);
         JFormattedTextField numberFormattedTextfield = new JFormattedTextField(decimalFormat);
         JPopupMenu popup = new JPopupMenu();
@@ -223,7 +228,7 @@ public class SwingUtil {
     /**
      * Formats a given double value correctly to String with given format
      * 
-     * @param value 
+     * @param value
      * @param format
      * @return
      */
@@ -252,7 +257,7 @@ public class SwingUtil {
     /**
      * Number string comparator based on its value.<br />
      * 
-     * @exception 
+     * @exception
      */
     public static final Comparator<String> NUMBER_COMPARATOR = (o1, o2) -> {
         try {
@@ -266,7 +271,7 @@ public class SwingUtil {
     /**
      * Balance string comparator based on its value.<br />
      * 
-     * @exception 
+     * @exception
      */
     public static final Comparator<String> BALANCE_COMPARATOR = (o1, o2) -> {
         try {
@@ -292,4 +297,5 @@ public class SwingUtil {
             throw new NumberFormatException(e.getLocalizedMessage());
         }
     };
+
 }

--- a/src/main/java/org/semux/gui/SwingUtil.java
+++ b/src/main/java/org/semux/gui/SwingUtil.java
@@ -195,22 +195,22 @@ public class SwingUtil {
 
     /**
      * Number string comparator based on its value.<br />
-     * * @exception throws IllegalArgumentException on ParseException
+     * @exception throws NumberFormatException on ParseException
      */
     public static final Comparator<String> NUMBER_COMPARATOR = (o1, o2) -> {
         try {
             return Double.compare(NumberFormat.getInstance().parse(o1).doubleValue(),
                     NumberFormat.getInstance().parse(o2).doubleValue());
         } catch (ParseException e) {
-            logger.error("NumberFormatException", e);
-            throw new IllegalArgumentException(e);
+            logger.error("Wrong format or value for parsing to Double", e);
+            throw new NumberFormatException(e.getLocalizedMessage());
         }
     };
 
     /**
      * Balance string comparator based on its value.<br />
      * 
-     * @exception throws IllegalArgumentException on ParseException
+     * @exception throws NumberFormatException on ParseException
      */
     public static final Comparator<String> BALANCE_COMPARATOR = (o1, o2) -> {
 
@@ -218,23 +218,23 @@ public class SwingUtil {
             return Double.compare(NumberFormat.getInstance().parse(o1.substring(0, o1.length() - 4)).doubleValue(),
                     NumberFormat.getInstance().parse(o2.substring(0, o2.length() - 4)).doubleValue());
         } catch (ParseException e) {
-            logger.error("NumberFormatException", e);
-            throw new IllegalArgumentException(e);
+            logger.error("Wrong format or value for parsing to Double", e);
+            throw new NumberFormatException(e.getLocalizedMessage());
         }
     };
 
     /**
      * Balance string comparator based on its value.<br />
      * 
-     * @exception throws IllegalArgumentException on ParseException
+     * @exception throws NumberFormatException on ParseException
      */
     public static final Comparator<String> PERCENTAGE_COMPARATOR = (o1, o2) -> {
         try {
             return Double.compare(NumberFormat.getInstance().parse(o1.substring(0, o1.length() - 2)).doubleValue(),
                     NumberFormat.getInstance().parse(o2.substring(0, o2.length() - 2)).doubleValue());
         } catch (ParseException e) {
-            logger.error("NumberFormatException", e);
-            throw new IllegalArgumentException(e);
+            logger.error("Wrong format or value for parsing to Double", e);
+            throw new NumberFormatException(e.getLocalizedMessage());
         }
     };
 }

--- a/src/main/java/org/semux/gui/dialog/TransactionDialog.java
+++ b/src/main/java/org/semux/gui/dialog/TransactionDialog.java
@@ -45,8 +45,10 @@ public class TransactionDialog extends JDialog {
         JLabel type = new JLabel(tx.getType().name());
         JTextArea from = selectableText(Hex.PREF + Hex.encode(tx.getFrom()));
         JTextArea to = selectableText(Hex.PREF + Hex.encode(tx.getTo()));
-        JLabel value = new JLabel(SwingUtil.formatDouble((tx.getValue() / Unit.SEM ),"0.000"+ " SEM"));
-        JLabel fee = new JLabel(SwingUtil.formatDouble((tx.getFee() / Unit.SEM ),"0.000"+ " SEM"));
+        JLabel value = new JLabel(
+                SwingUtil.formatDouble((tx.getValue() / Unit.SEM), SwingUtil.DEFAULT_DOUBLE_FORMAT + " SEM"));
+        JLabel fee = new JLabel(
+                SwingUtil.formatDouble((tx.getFee() / Unit.SEM), SwingUtil.DEFAULT_DOUBLE_FORMAT + " SEM"));
         JLabel nonce = new JLabel(Long.toString(tx.getNonce()));
         JLabel timestamp = new JLabel(new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(new Date(tx.getTimestamp())));
         JTextArea data = new JTextArea(Hex.PREF + Hex.encode(tx.getData()));

--- a/src/main/java/org/semux/gui/dialog/TransactionDialog.java
+++ b/src/main/java/org/semux/gui/dialog/TransactionDialog.java
@@ -15,6 +15,7 @@ import javax.swing.LayoutStyle.ComponentPlacement;
 import org.semux.core.Transaction;
 import org.semux.core.Unit;
 import org.semux.crypto.Hex;
+import org.semux.gui.SwingUtil;
 
 public class TransactionDialog extends JDialog {
 
@@ -44,8 +45,8 @@ public class TransactionDialog extends JDialog {
         JLabel type = new JLabel(tx.getType().name());
         JTextArea from = selectableText(Hex.PREF + Hex.encode(tx.getFrom()));
         JTextArea to = selectableText(Hex.PREF + Hex.encode(tx.getTo()));
-        JLabel value = new JLabel(tx.getValue() / Unit.SEM + " SEM");
-        JLabel fee = new JLabel(tx.getFee() / Unit.SEM + " SEM");
+        JLabel value = new JLabel(SwingUtil.formatDouble((tx.getValue() / Unit.SEM ),"0.000"+ " SEM"));
+        JLabel fee = new JLabel(SwingUtil.formatDouble((tx.getFee() / Unit.SEM ),"0.000"+ " SEM"));
         JLabel nonce = new JLabel(Long.toString(tx.getNonce()));
         JLabel timestamp = new JLabel(new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(new Date(tx.getTimestamp())));
         JTextArea data = new JTextArea(Hex.PREF + Hex.encode(tx.getData()));

--- a/src/main/java/org/semux/gui/panel/DelegatesPanel.java
+++ b/src/main/java/org/semux/gui/panel/DelegatesPanel.java
@@ -148,7 +148,7 @@ public class DelegatesPanel extends JPanel implements ActionListener {
         setLayout(groupLayout); 
         // @formatter:on
 
-        textVote = SwingUtil.editableTextField();
+        textVote = SwingUtil.integerFormattedTextField();
         textVote.setToolTipText("# of votes");
         textVote.setColumns(10);
         textVote.setActionCommand(Action.VOTE.name());
@@ -158,7 +158,7 @@ public class DelegatesPanel extends JPanel implements ActionListener {
         btnVote.setActionCommand(Action.VOTE.name());
         btnVote.addActionListener(this);
 
-        textUnvote = SwingUtil.editableTextField();
+        textUnvote = SwingUtil.integerFormattedTextField();
         textUnvote.setToolTipText("# of votes");
         textUnvote.setColumns(10);
         textUnvote.setActionCommand(Action.UNVOTE.name());

--- a/src/main/java/org/semux/gui/panel/DelegatesPanel.java
+++ b/src/main/java/org/semux/gui/panel/DelegatesPanel.java
@@ -290,7 +290,7 @@ public class DelegatesPanel extends JPanel implements ActionListener {
                 List<String> validators = Kernel.getInstance().getBlockchain().getValidators();
                 return new HashSet<>(validators).contains(Hex.encode(d.getAddress())) ? "V" : "S";
             case 6:
-                return String.format("%.1f %%", d.getRate());
+                return String.format("%s %%", SwingUtil.formatDouble(d.getRate(), "0.0"));
             default:
                 return null;
             }
@@ -404,7 +404,7 @@ public class DelegatesPanel extends JPanel implements ActionListener {
         List<String> accounts = new ArrayList<>();
         List<Account> list = model.getAccounts();
         for (int i = 0; i < list.size(); i++) {
-            accounts.add("Acc #" + i + ", " + list.get(i).getBalance() / Unit.SEM + " SEM");
+            accounts.add(String.format("Acc #%d, %s SEM",i, SwingUtil.formatDouble(list.get(i).getBalance() / Unit.SEM, "0.000")));
         }
 
         /*

--- a/src/main/java/org/semux/gui/panel/DelegatesPanel.java
+++ b/src/main/java/org/semux/gui/panel/DelegatesPanel.java
@@ -404,7 +404,7 @@ public class DelegatesPanel extends JPanel implements ActionListener {
         List<String> accounts = new ArrayList<>();
         List<Account> list = model.getAccounts();
         for (int i = 0; i < list.size(); i++) {
-            accounts.add(String.format("Acc #%d, %s SEM",i, SwingUtil.formatDouble(list.get(i).getBalance() / Unit.SEM, "0.000")));
+            accounts.add(String.format("Acc #%d, %s SEM",i, SwingUtil.formatDouble(list.get(i).getBalance() / Unit.SEM, "0")));
         }
 
         /*

--- a/src/main/java/org/semux/gui/panel/HomePanel.java
+++ b/src/main/java/org/semux/gui/panel/HomePanel.java
@@ -155,7 +155,7 @@ public class HomePanel extends JPanel implements ActionListener {
 
             String prefix = (inBound && outBound) ? "" : (inBound ? "+" : "-");
             JLabel lblAmount = new JLabel(String.format("%s%s SEM", prefix,
-                    SwingUtil.formatDouble((tx.getValue() / (double) Unit.SEM), "0.000")));
+                    SwingUtil.formatDouble((tx.getValue() / (double) Unit.SEM), SwingUtil.DEFAULT_DOUBLE_FORMAT)));
             lblAmount.setHorizontalAlignment(SwingConstants.RIGHT);
 
             SimpleDateFormat df = new SimpleDateFormat("MM/dd HH:mm:ss");

--- a/src/main/java/org/semux/gui/panel/HomePanel.java
+++ b/src/main/java/org/semux/gui/panel/HomePanel.java
@@ -219,8 +219,8 @@ public class HomePanel extends JPanel implements ActionListener {
         this.blockTime.setText(new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(new Date(block.getTimestamp())));
         this.coinbase.setText("Account #" + model.getCoinbase());
         this.status.setText(model.isDelegate() ? "Delegate" : "Normal");
-        this.balance.setText(String.format("%.3f SEM", model.getTotalBalance() / (double) Unit.SEM));
-        this.locked.setText(String.format("%.3f SEM", model.getTotalLocked() / (double) Unit.SEM));
+        this.balance.setText(String.format("%s SEM", SwingUtil.formatDouble(model.getTotalBalance() / (double) Unit.SEM, "0.000")));
+        this.locked.setText(String.format("%s SEM", SwingUtil.formatDouble(model.getTotalLocked() / (double) Unit.SEM,"0.000")));
         this.peers.setText(Integer.toString(model.getActivePeers().size()));
 
         // federate all transactions

--- a/src/main/java/org/semux/gui/panel/HomePanel.java
+++ b/src/main/java/org/semux/gui/panel/HomePanel.java
@@ -154,7 +154,8 @@ public class HomePanel extends JPanel implements ActionListener {
             lblType.setIcon(SwingUtil.loadImage(name, 48, 48));
 
             String prefix = (inBound && outBound) ? "" : (inBound ? "+" : "-");
-            JLabel lblAmount = new JLabel(String.format("%s%.3f SEM", prefix, tx.getValue() / (double) Unit.SEM));
+            JLabel lblAmount = new JLabel(String.format("%s%s SEM", prefix,
+                    SwingUtil.formatDouble((tx.getValue() / (double) Unit.SEM), "0.000")));
             lblAmount.setHorizontalAlignment(SwingConstants.RIGHT);
 
             SimpleDateFormat df = new SimpleDateFormat("MM/dd HH:mm:ss");
@@ -219,8 +220,10 @@ public class HomePanel extends JPanel implements ActionListener {
         this.blockTime.setText(new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(new Date(block.getTimestamp())));
         this.coinbase.setText("Account #" + model.getCoinbase());
         this.status.setText(model.isDelegate() ? "Delegate" : "Normal");
-        this.balance.setText(String.format("%s SEM", SwingUtil.formatDouble(model.getTotalBalance() / (double) Unit.SEM, "0.000")));
-        this.locked.setText(String.format("%s SEM", SwingUtil.formatDouble(model.getTotalLocked() / (double) Unit.SEM,"0.000")));
+        this.balance.setText(String.format("%s SEM",
+                SwingUtil.formatDouble(model.getTotalBalance() / (double) Unit.SEM, SwingUtil.DEFAULT_DOUBLE_FORMAT)));
+        this.locked.setText(String.format("%s SEM",
+                SwingUtil.formatDouble(model.getTotalLocked() / (double) Unit.SEM, SwingUtil.DEFAULT_DOUBLE_FORMAT)));
         this.peers.setText(Integer.toString(model.getActivePeers().size()));
 
         // federate all transactions

--- a/src/main/java/org/semux/gui/panel/ReceivePanel.java
+++ b/src/main/java/org/semux/gui/panel/ReceivePanel.java
@@ -165,9 +165,9 @@ public class ReceivePanel extends JPanel implements ActionListener {
             case 1:
                 return "0x" + acc.getKey().toAddressString();
             case 2:
-                return String.format("%.3f SEM", acc.getBalance() / (double) Unit.SEM);
+                return String.format("%s SEM", SwingUtil.formatDouble((acc.getBalance() / (double) Unit.SEM),"0.000"));
             case 3:
-                return String.format("%.3f SEM", acc.getLocked() / (double) Unit.SEM);
+                return String.format("%s SEM", SwingUtil.formatDouble((acc.getLocked() / (double) Unit.SEM),"0.000"));
             default:
                 return null;
             }

--- a/src/main/java/org/semux/gui/panel/ReceivePanel.java
+++ b/src/main/java/org/semux/gui/panel/ReceivePanel.java
@@ -165,9 +165,11 @@ public class ReceivePanel extends JPanel implements ActionListener {
             case 1:
                 return "0x" + acc.getKey().toAddressString();
             case 2:
-                return String.format("%s SEM", SwingUtil.formatDouble((acc.getBalance() / (double) Unit.SEM),"0.000"));
+                return String.format("%s SEM", SwingUtil.formatDouble((acc.getBalance() / (double) Unit.SEM),
+                        SwingUtil.DEFAULT_DOUBLE_FORMAT));
             case 3:
-                return String.format("%s SEM", SwingUtil.formatDouble((acc.getLocked() / (double) Unit.SEM),"0.000"));
+                return String.format("%s SEM",
+                        SwingUtil.formatDouble((acc.getLocked() / (double) Unit.SEM), SwingUtil.DEFAULT_DOUBLE_FORMAT));
             default:
                 return null;
             }

--- a/src/main/java/org/semux/gui/panel/SendPanel.java
+++ b/src/main/java/org/semux/gui/panel/SendPanel.java
@@ -186,7 +186,7 @@ public class SendPanel extends JPanel implements ActionListener {
     }
 
     public void setAmount(long a) {
-        amount.setText(a == 0 ? "" : String.format("%.3f", a / (double) Unit.SEM));
+        amount.setText(a == 0 ? "" :SwingUtil.formatDouble( a / (double) Unit.SEM,"0.000"));
     }
 
     /**

--- a/src/main/java/org/semux/gui/panel/SendPanel.java
+++ b/src/main/java/org/semux/gui/panel/SendPanel.java
@@ -173,14 +173,15 @@ public class SendPanel extends JPanel implements ActionListener {
 
     /**
      * @return the submitted amount of coins as long
-     * @exception IllegalArgumentException on ParseException
+     * @exception NumberFormatException on ParseException
      */
     public long getAmount() {
         try {
             return (long) (Unit.SEM * NumberFormat.getInstance().parse(amount.getText().trim()).doubleValue());
         } catch (ParseException e) {
             logger.error("Parsing of submitted value of amount failed", e);
-            throw new IllegalArgumentException(e);
+            JOptionPane.showMessageDialog(this, "Submitted fee is invalid!");
+            throw new NumberFormatException(e.getLocalizedMessage());
         }
     }
 
@@ -190,14 +191,15 @@ public class SendPanel extends JPanel implements ActionListener {
 
     /**
      * @return the submitted Fee as long 
-     * @exception IllegalArgumentException on ParseException
+     * @exception NumberFormatException on ParseException
      */
     public long getFee() {
         try {
             return (long) (Unit.SEM * NumberFormat.getInstance().parse(fee.getText().trim()).doubleValue());
         } catch (ParseException e) {
             logger.error("Parsing of submitted value of fee failed", e);
-            throw new IllegalArgumentException(e);
+            JOptionPane.showMessageDialog(this, "Submitted fee is invalid!");
+            throw new NumberFormatException(e.getLocalizedMessage());
         }
     }
 

--- a/src/main/java/org/semux/gui/panel/SendPanel.java
+++ b/src/main/java/org/semux/gui/panel/SendPanel.java
@@ -186,7 +186,7 @@ public class SendPanel extends JPanel implements ActionListener {
     }
 
     public void setAmount(long a) {
-        amount.setText(a == 0 ? "" :SwingUtil.formatDouble( a / (double) Unit.SEM,"0.000"));
+        amount.setText(a == 0 ? "" : SwingUtil.formatDouble(a / (double) Unit.SEM, SwingUtil.DEFAULT_DOUBLE_FORMAT));
     }
 
     /**
@@ -205,7 +205,7 @@ public class SendPanel extends JPanel implements ActionListener {
     }
 
     public void setFee(long f) {
-        fee.setText(f == 0 ? "" : SwingUtil.formatDouble( f / (double) Unit.SEM,"0.000"));
+        fee.setText(f == 0 ? "" : SwingUtil.formatDouble(f / (double) Unit.SEM, SwingUtil.DEFAULT_DOUBLE_FORMAT));
     }
 
     @Override
@@ -232,7 +232,9 @@ public class SendPanel extends JPanel implements ActionListener {
                 JOptionPane.showMessageDialog(this, "Invalid receiving address!");
             } else {
                 int ret = JOptionPane.showConfirmDialog(this,
-                        "Are you sure you want to transfer " + SwingUtil.formatDouble(value / Unit.SEM,"0.000") + " SEM to 0x" + Hex.encode(to) + "?",
+                        "Are you sure you want to transfer "
+                                + SwingUtil.formatDouble(value / Unit.SEM, SwingUtil.DEFAULT_DOUBLE_FORMAT)
+                                + " SEM to 0x" + Hex.encode(to) + "?",
                         "Confirm transfer", JOptionPane.YES_NO_OPTION);
                 if (ret != JOptionPane.YES_OPTION) {
                     break;

--- a/src/main/java/org/semux/gui/panel/SendPanel.java
+++ b/src/main/java/org/semux/gui/panel/SendPanel.java
@@ -171,28 +171,34 @@ public class SendPanel extends JPanel implements ActionListener {
         to.setText(Hex.encode(addr));
     }
 
+    /**
+     * @return the submitted amount of coins as long
+     * @exception IllegalArgumentException on ParseException
+     */
     public long getAmount() {
         try {
             return (long) (Unit.SEM * NumberFormat.getInstance().parse(amount.getText().trim()).doubleValue());
         } catch (ParseException e) {
-            logger.error("NumberFormatException", e);
+            logger.error("Parsing of submitted value of amount failed", e);
+            throw new IllegalArgumentException(e);
         }
-        // we should never come here -> work or exception
-        return 0;
     }
 
     public void setAmount(long a) {
         amount.setText(a == 0 ? "" : String.format("%.3f", a / (double) Unit.SEM));
     }
 
+    /**
+     * @return the submitted Fee as long 
+     * @exception IllegalArgumentException on ParseException
+     */
     public long getFee() {
         try {
             return (long) (Unit.SEM * NumberFormat.getInstance().parse(fee.getText().trim()).doubleValue());
         } catch (ParseException e) {
-            logger.error("NumberFormatException", e);
+            logger.error("Parsing of submitted value of fee failed", e);
+            throw new IllegalArgumentException(e);
         }
-        // we should never come here -> work or exception
-        return 0;
     }
 
     public void setFee(long f) {

--- a/src/main/java/org/semux/gui/panel/SendPanel.java
+++ b/src/main/java/org/semux/gui/panel/SendPanel.java
@@ -4,6 +4,8 @@ import java.awt.Color;
 import java.awt.Font;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.text.NumberFormat;
+import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -31,8 +33,12 @@ import org.semux.gui.Model.Account;
 import org.semux.gui.SwingUtil;
 import org.semux.utils.Bytes;
 import org.semux.utils.UnreachableException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class SendPanel extends JPanel implements ActionListener {
+
+    private static final Logger logger = LoggerFactory.getLogger(SwingUtil.class);
 
     private static final long serialVersionUID = 1L;
 
@@ -166,7 +172,13 @@ public class SendPanel extends JPanel implements ActionListener {
     }
 
     public long getAmount() {
-        return (long) (Unit.SEM * Double.parseDouble(amount.getText().trim()));
+        try {
+            return (long) (Unit.SEM * NumberFormat.getInstance().parse(amount.getText().trim()).doubleValue());
+        } catch (ParseException e) {
+            logger.error("NumberFormatException", e);
+        }
+        // we should never come here -> work or exception
+        return 0;
     }
 
     public void setAmount(long a) {
@@ -174,7 +186,13 @@ public class SendPanel extends JPanel implements ActionListener {
     }
 
     public long getFee() {
-        return (long) (Unit.SEM * Double.parseDouble(fee.getText().trim()));
+        try {
+            return (long) (Unit.SEM * NumberFormat.getInstance().parse(fee.getText().trim()).doubleValue());
+        } catch (ParseException e) {
+            logger.error("NumberFormatException", e);
+        }
+        // we should never come here -> work or exception
+        return 0;
     }
 
     public void setFee(long f) {

--- a/src/main/java/org/semux/gui/panel/SendPanel.java
+++ b/src/main/java/org/semux/gui/panel/SendPanel.java
@@ -4,8 +4,6 @@ import java.awt.Color;
 import java.awt.Font;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-import java.text.NumberFormat;
-import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -13,6 +11,7 @@ import javax.swing.GroupLayout;
 import javax.swing.GroupLayout.Alignment;
 import javax.swing.JButton;
 import javax.swing.JComboBox;
+import javax.swing.JFormattedTextField;
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
@@ -46,8 +45,8 @@ public class SendPanel extends JPanel implements ActionListener {
 
     private JComboBox<String> from;
     private JTextField to;
-    private JTextField amount;
-    private JTextField fee;
+    private JFormattedTextField amount;
+    private JFormattedTextField fee;
 
     public SendPanel(Model model) {
         this.model = model;
@@ -72,7 +71,7 @@ public class SendPanel extends JPanel implements ActionListener {
         JLabel lblAmount = new JLabel("Amount:");
         lblAmount.setHorizontalAlignment(SwingConstants.RIGHT);
 
-        amount = SwingUtil.editableTextField();
+        amount = SwingUtil.doubleFormattedTextField();
         amount.setColumns(10);
         amount.setActionCommand(Action.SEND.name());
         amount.addActionListener(this);
@@ -80,7 +79,7 @@ public class SendPanel extends JPanel implements ActionListener {
         JLabel lblFee = new JLabel("Fee:");
         lblFee.setHorizontalAlignment(SwingConstants.RIGHT);
 
-        fee = SwingUtil.editableTextField();
+        fee = SwingUtil.doubleFormattedTextField();
         fee.setColumns(10);
         fee.setActionCommand(Action.SEND.name());
         fee.addActionListener(this);
@@ -173,15 +172,16 @@ public class SendPanel extends JPanel implements ActionListener {
 
     /**
      * @return the submitted amount of coins as long
-     * @exception NumberFormatException on ParseException
+     * @exception NumberFormatException
+     *                if Double.parseDouble() fails
      */
     public long getAmount() {
         try {
-            return (long) (Unit.SEM * NumberFormat.getInstance().parse(amount.getText().trim()).doubleValue());
-        } catch (ParseException e) {
+            return (long) (Unit.SEM * Double.parseDouble(amount.getText().trim().replaceAll(",", ".")));
+        } catch (NumberFormatException e) {
             logger.error("Parsing of submitted value of amount failed", e);
             JOptionPane.showMessageDialog(this, "Submitted fee is invalid!");
-            throw new NumberFormatException(e.getLocalizedMessage());
+            throw e;
         }
     }
 
@@ -190,21 +190,22 @@ public class SendPanel extends JPanel implements ActionListener {
     }
 
     /**
-     * @return the submitted Fee as long 
-     * @exception NumberFormatException on ParseException
+     * @return the submitted Fee as long
+     * @exception NumberFormatException
+     *                if Double.parseDouble() fails
      */
     public long getFee() {
         try {
-            return (long) (Unit.SEM * NumberFormat.getInstance().parse(fee.getText().trim()).doubleValue());
-        } catch (ParseException e) {
+            return (long) (Unit.SEM * Double.parseDouble(fee.getText().trim().replaceAll(",", ".")));
+        } catch (NumberFormatException e) {
             logger.error("Parsing of submitted value of fee failed", e);
             JOptionPane.showMessageDialog(this, "Submitted fee is invalid!");
-            throw new NumberFormatException(e.getLocalizedMessage());
+            throw e;
         }
     }
 
     public void setFee(long f) {
-        fee.setText(f == 0 ? "" : String.format("%.3f", f / (double) Unit.SEM));
+        fee.setText(f == 0 ? "" : SwingUtil.formatDouble( f / (double) Unit.SEM,"0.000"));
     }
 
     @Override
@@ -231,7 +232,7 @@ public class SendPanel extends JPanel implements ActionListener {
                 JOptionPane.showMessageDialog(this, "Invalid receiving address!");
             } else {
                 int ret = JOptionPane.showConfirmDialog(this,
-                        "Are you sure you want to transfer " + value / Unit.SEM + " SEM to 0x" + Hex.encode(to) + "?",
+                        "Are you sure you want to transfer " + SwingUtil.formatDouble(value / Unit.SEM,"0.000") + " SEM to 0x" + Hex.encode(to) + "?",
                         "Confirm transfer", JOptionPane.YES_NO_OPTION);
                 if (ret != JOptionPane.YES_OPTION) {
                     break;

--- a/src/main/java/org/semux/gui/panel/TransactionsPanel.java
+++ b/src/main/java/org/semux/gui/panel/TransactionsPanel.java
@@ -153,7 +153,7 @@ public class TransactionsPanel extends JPanel implements ActionListener {
                 to = accounts.containsKey(to) ? "Account #" + accounts.get(to) : "0x" + to;
                 return from + " => " + to;
             case 2:
-                return String.format("%.3f SEM", tx.getValue() / (double) Unit.SEM);
+                return String.format("%s SEM",SwingUtil.formatDouble( tx.getValue() / (double) Unit.SEM, SwingUtil.DEFAULT_DOUBLE_FORMAT));
             case 3:
                 SimpleDateFormat df = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
                 return df.format(new Date(tx.getTimestamp()));

--- a/src/test/java/org/semux/gui/SwingUtilTest.java
+++ b/src/test/java/org/semux/gui/SwingUtilTest.java
@@ -1,0 +1,44 @@
+package org.semux.gui;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Locale;
+
+import org.junit.Test;
+
+public class SwingUtilTest {
+
+    private String goodDoubleString1 = "1.0000";
+    private String goodDoubleString2 = "2.25";
+
+    private String badDoubleString1 = "2f.25test";
+    private String badDoubleString2 = "worstWordt";
+
+    @Test
+    public void testNumberComparator() {
+        Locale.setDefault(new Locale("us", "US"));
+
+        // String 1 < String 2
+        long compareResult1 = SwingUtil.NUMBER_COMPARATOR.compare(goodDoubleString1, goodDoubleString2);
+        assertEquals(-1L, compareResult1, 0L);
+
+        // String 1 > String 2
+        long compareResult2 = SwingUtil.NUMBER_COMPARATOR.compare(goodDoubleString2, goodDoubleString1);
+        assertEquals(1L, compareResult2, 0L);
+
+        // String 1 == String 2
+        long compareResult3 = SwingUtil.NUMBER_COMPARATOR.compare(goodDoubleString1, goodDoubleString1);
+        assertEquals(0L, compareResult3, 0L);
+    }
+
+    @Test(expected = NumberFormatException.class)
+    public void testNumberComparatorExceptionPartiallyWrongInput() {
+        SwingUtil.NUMBER_COMPARATOR.compare(goodDoubleString1, badDoubleString1);
+    }
+
+    @Test(expected = NumberFormatException.class)
+    public void testNumberComparatorExceptionTotallyWrongInput() {
+        SwingUtil.NUMBER_COMPARATOR.compare(goodDoubleString1, badDoubleString2);
+    }
+
+}


### PR DESCRIPTION
Localized double values use different decimal seperators. 
Double.parse(str) can't handle this.
Fixed it with using NumberFormat.parse(str).doubleValue()