### PR TITLE
Tests: add launch4j integration test

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,7 @@ clone_folder: C:\projects\semux
 environment:
   matrix:
     - JAVA_HOME: C:\Program Files\Java\jdk1.8.0
+      Launch4j: debug
 
 install:
   - echo %PATH%
@@ -17,7 +18,7 @@ build_script:
   - mvn clean install -DskipTests
 
 test_script:
-  - mvn test
+  - mvn verify
 
 cache:
   - C:\Users\appveyor\.m2\

--- a/pom.xml
+++ b/pom.xml
@@ -144,9 +144,10 @@
                                         <include name="semux.exe"/>
                                     </fileset>
                                 </copy>
-                                <copy file="${project.basedir}/misc/launch4j/semux.l4j.ini" tofile="${dist.base}/windows/semux.l4j.ini" />
-                                <fixcrlf srcdir="${dist.base}/windows" includes="**/*.ini" eol="dos" eof="asis" />
-                                <fixcrlf srcdir="${dist.base}/windows" includes="config/*" eol="dos" eof="asis" />
+                                <copy file="${project.basedir}/misc/launch4j/semux.l4j.ini"
+                                      tofile="${dist.base}/windows/semux.l4j.ini"/>
+                                <fixcrlf srcdir="${dist.base}/windows" includes="**/*.ini" eol="dos" eof="asis"/>
+                                <fixcrlf srcdir="${dist.base}/windows" includes="config/*" eol="dos" eof="asis"/>
 
                                 <!-- unix build (executable jar) -->
                                 <copy todir="${dist.base}/unix">
@@ -155,15 +156,18 @@
                                         <include name="LICENSE"/>
                                     </fileset>
                                 </copy>
-                                <copy file="${project.basedir}/target/semux-${project.version}-shaded.jar" tofile="${dist.base}/unix/semux.jar" />
-                                <copy file="${project.basedir}/scripts/semux-cli.sh" tofile="${dist.base}/unix/semux-cli.sh" />
-                                <copy file="${project.basedir}/scripts/semux-gui.sh" tofile="${dist.base}/unix/semux-gui.sh" />
+                                <copy file="${project.basedir}/target/semux-${project.version}-shaded.jar"
+                                      tofile="${dist.base}/unix/semux.jar"/>
+                                <copy file="${project.basedir}/scripts/semux-cli.sh"
+                                      tofile="${dist.base}/unix/semux-cli.sh"/>
+                                <copy file="${project.basedir}/scripts/semux-gui.sh"
+                                      tofile="${dist.base}/unix/semux-gui.sh"/>
 
                                 <!-- unix build (executable jar) -->
                                 <copy todir="${dist.base}/macos">
-                                    <fileset dir="${dist.base}/unix" />
+                                    <fileset dir="${dist.base}/unix"/>
                                 </copy>
-                                
+
                                 <!-- add execute permission -->
                                 <chmod file="${dist.base}/windows/semux.exe" perm="755"/>
                                 <chmod file="${dist.base}/unix/semux.jar" perm="755"/>
@@ -252,6 +256,8 @@
                     <classpathDependencyExcludes>
                         <classpathDependencyExcludes>ch.qos.logback:logback-classic</classpathDependencyExcludes>
                     </classpathDependencyExcludes>
+                    <excludedGroups>org.semux.IntegrationTest</excludedGroups>
+                    <goal>test</goal>
                 </configuration>
             </plugin>
         </plugins>
@@ -389,4 +395,41 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <profiles>
+        <profile>
+            <id>windows</id>
+            <activation>
+                <os>
+                    <family>windows</family>
+                </os>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <version>2.20.1</version>
+                        <configuration>
+                            <groups>org.semux.windows.WindowsIntegrationTest</groups>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>integration-test</id>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>verify</id>
+                                <goals>
+                                    <goal>verify</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/src/test/java/org/semux/IntegrationTest.java
+++ b/src/test/java/org/semux/IntegrationTest.java
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) 2017 The Semux Developers
+ *
+ * Distributed under the MIT software license, see the accompanying file
+ * LICENSE or https://opensource.org/licenses/mit-license.php
+ */
+package org.semux;
+
+public interface IntegrationTest {
+}

--- a/src/test/java/org/semux/windows/Launch4jWrapperIT.java
+++ b/src/test/java/org/semux/windows/Launch4jWrapperIT.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2017 The Semux Developers
+ *
+ * Distributed under the MIT software license, see the accompanying file
+ * LICENSE or https://opensource.org/licenses/mit-license.php
+ */
+package org.semux.windows;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@Category(org.semux.windows.WindowsIntegrationTest.class)
+public class Launch4jWrapperIT {
+
+    @Test
+    public void testLaunch4jWrapper() throws IOException, InterruptedException {
+        Path prefix = Paths.get(System.getProperty("user.dir"), "dist", "windows");
+        Path semuxExePath = Paths.get(prefix.toString(), "semux.exe");
+        Process l4jWrapper = new ProcessBuilder(semuxExePath.toString(), "").directory(prefix.toFile()).start();
+
+        int limit = 5;
+        Path l4jLogPath = Paths.get(prefix.toString(), "launch4j.log");
+        while (!l4jLogPath.toFile().exists()) {
+            TimeUnit.SECONDS.sleep(1);
+            if (--limit == 0) {
+                assertFalse("launch4j.log is not created", false);
+            }
+        }
+
+        assertTrue("The exit code of launch4j wrapper should be 0",
+                Files.lines(l4jLogPath).anyMatch(str -> str.matches("Exit code:\\s+0")));
+
+        l4jWrapper.destroyForcibly();
+    }
+
+}

--- a/src/test/java/org/semux/windows/WindowsIntegrationTest.java
+++ b/src/test/java/org/semux/windows/WindowsIntegrationTest.java
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) 2017 The Semux Developers
+ *
+ * Distributed under the MIT software license, see the accompanying file
+ * LICENSE or https://opensource.org/licenses/mit-license.php
+ */
+package org.semux.windows;
+
+import org.semux.IntegrationTest;
+
+public interface WindowsIntegrationTest extends IntegrationTest {
+}


### PR DESCRIPTION
To resolve #228 

The pull request adds a windows-specific integration test for checking whether the created Launch4j wrapper can be successfully executed. 