### PR TITLE
Increase Synchronization Performance by Caching EdDSAPublicKey

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -359,6 +359,13 @@
             <version>3.4.4</version>
         </dependency>
 
+        <!-- Google Guava -->
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>23.5-jre</version>
+        </dependency>
+
         <!-- Testing Libraries -->
         <dependency>
             <groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -359,11 +359,11 @@
             <version>3.4.4</version>
         </dependency>
 
-        <!-- Google Guava -->
+        <!-- Caffeine Caching Library -->
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>23.5-jre</version>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+            <version>2.6.0</version>
         </dependency>
 
         <!-- Testing Libraries -->

--- a/src/main/java/org/semux/consensus/SemuxSync.java
+++ b/src/main/java/org/semux/consensus/SemuxSync.java
@@ -44,6 +44,7 @@ import org.semux.net.ChannelManager;
 import org.semux.net.msg.Message;
 import org.semux.net.msg.consensus.BlockMessage;
 import org.semux.net.msg.consensus.GetBlockMessage;
+import org.semux.util.TimeUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -157,9 +158,7 @@ public class SemuxSync implements Sync {
             try {
                 exec.awaitTermination(1, TimeUnit.MINUTES);
                 end = Instant.now();
-                long durationSeconds = Duration.between(begin, end).getSeconds();
-                logger.info(String.format("Syncing finished, took %02d:%02d:%02d", durationSeconds / 3600,
-                        (durationSeconds % 3600) / 60, (durationSeconds % 60)));
+                logger.info("Syncing finished, took {}", TimeUtil.formatDuration(Duration.between(begin, end)));
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 logger.error("Executors were not properly shut down");

--- a/src/main/java/org/semux/crypto/EdDSA.java
+++ b/src/main/java/org/semux/crypto/EdDSA.java
@@ -156,6 +156,7 @@ public class EdDSA {
 
     /**
      * Returns cached EdDSAPublicKey hashed by hexadecimal message signature
+     * 
      * @param signature
      * @return
      */

--- a/src/main/java/org/semux/crypto/cache/EdDSAPublicKeyCache.java
+++ b/src/main/java/org/semux/crypto/cache/EdDSAPublicKeyCache.java
@@ -1,19 +1,19 @@
 /**
  * Copyright (c) 2017 The Semux Developers
- *
+ * <p>
  * Distributed under the MIT software license, see the accompanying file
  * LICENSE or https://opensource.org/licenses/mit-license.php
  */
 package org.semux.crypto.cache;
 
-import com.google.common.cache.CacheBuilder;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import net.i2p.crypto.eddsa.EdDSAPublicKey;
 import org.semux.crypto.CryptoException;
 import org.semux.crypto.Hex;
 
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.X509EncodedKeySpec;
-import java.util.concurrent.ConcurrentMap;
 
 public final class EdDSAPublicKeyCache {
 
@@ -27,8 +27,7 @@ public final class EdDSAPublicKeyCache {
      * <p>
      * softValues() allows GC to cleanup cached values automatically.
      */
-    private static final ConcurrentMap<String, EdDSAPublicKey> pubKeyCache = CacheBuilder.newBuilder().softValues()
-            .<String, EdDSAPublicKey>build().asMap();
+    private static final Cache<String, EdDSAPublicKey> pubKeyCache = Caffeine.newBuilder().softValues().build();
 
     private EdDSAPublicKeyCache() {
     }
@@ -40,7 +39,7 @@ public final class EdDSAPublicKeyCache {
      * @return
      */
     public static final EdDSAPublicKey computeIfAbsent(byte[] pubKey) {
-        return pubKeyCache.computeIfAbsent(Hex.encode(pubKey), input -> {
+        return pubKeyCache.get(Hex.encode(pubKey), input -> {
             try {
                 return new EdDSAPublicKey(new X509EncodedKeySpec(pubKey));
             } catch (InvalidKeySpecException e) {

--- a/src/main/java/org/semux/crypto/cache/EdDSAPublicKeyCache.java
+++ b/src/main/java/org/semux/crypto/cache/EdDSAPublicKeyCache.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2017 The Semux Developers
+ *
+ * Distributed under the MIT software license, see the accompanying file
+ * LICENSE or https://opensource.org/licenses/mit-license.php
+ */
+package org.semux.crypto.cache;
+
+import com.google.common.cache.CacheBuilder;
+import net.i2p.crypto.eddsa.EdDSAPublicKey;
+import org.semux.crypto.CryptoException;
+import org.semux.crypto.Hex;
+
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.X509EncodedKeySpec;
+import java.util.concurrent.ConcurrentMap;
+
+public final class EdDSAPublicKeyCache {
+
+    /**
+     * EdDSAPublicKey constructor consumes ~37% of CPU time of
+     * EdDSAPublicKey::verify mainly by creating precomputed tables. Considering
+     * that Semux has an infrequently changed list of validators, caching public
+     * keys can reduce the synchronization time significantly.
+     * <p>
+     * The cache is a concurrent hash map of Hex(byte[] pubkey) -> EdDSAPublicKey
+     * <p>
+     * softValues() allows GC to cleanup cached values automatically.
+     */
+    private static final ConcurrentMap<String, EdDSAPublicKey> pubKeyCache = CacheBuilder.newBuilder().softValues()
+            .<String, EdDSAPublicKey>build().asMap();
+
+    private EdDSAPublicKeyCache() {
+    }
+
+    /**
+     * Returns cached EdDSAPublicKey hashed by hexadecimal public key
+     *
+     * @param pubKey
+     * @return
+     */
+    public static final EdDSAPublicKey computeIfAbsent(byte[] pubKey) {
+        return pubKeyCache.computeIfAbsent(Hex.encode(pubKey), input -> {
+            try {
+                return new EdDSAPublicKey(new X509EncodedKeySpec(pubKey));
+            } catch (InvalidKeySpecException e) {
+                throw new CryptoException(e);
+            }
+        });
+    }
+}

--- a/src/main/java/org/semux/util/TimeUtil.java
+++ b/src/main/java/org/semux/util/TimeUtil.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2017 The Semux Developers
+ *
+ * Distributed under the MIT software license, see the accompanying file
+ * LICENSE or https://opensource.org/licenses/mit-license.php
+ */
+package org.semux.util;
+
+import java.time.Duration;
+
+public class TimeUtil {
+
+    private TimeUtil() {
+    }
+
+    /**
+     * Returns a human-readable duration
+     * 
+     * @param duration
+     * @return
+     */
+    public static String formatDuration(Duration duration) {
+        long seconds = duration.getSeconds();
+        return String.format("%02d:%02d:%02d", seconds / 3600, (seconds % 3600) / 60, (seconds % 60));
+    }
+}

--- a/src/test/java/org/semux/bench/CorePerformance.java
+++ b/src/test/java/org/semux/bench/CorePerformance.java
@@ -23,7 +23,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class CorePerformance {
-    private static final Logger logger = LoggerFactory.getLogger(CryptoPerformance.class);
+    private static final Logger logger = LoggerFactory.getLogger(CorePerformance.class);
 
     public static Block testBlockCreation() {
         EdDSA key = new EdDSA();

--- a/src/test/java/org/semux/bench/CryptoLargePerformance.java
+++ b/src/test/java/org/semux/bench/CryptoLargePerformance.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) 2017 The Semux Developers
+ *
+ * Distributed under the MIT software license, see the accompanying file
+ * LICENSE or https://opensource.org/licenses/mit-license.php
+ */
+package org.semux.bench;
+
+import org.semux.crypto.EdDSA;
+import org.semux.crypto.Hash;
+import org.semux.util.TimeUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Random;
+
+public class CryptoLargePerformance {
+    private static final Logger logger = LoggerFactory.getLogger(CryptoLargePerformance.class);
+
+    private static final long TIMES = 10000;
+    private static final int SIZE = 1024 * 1024; // 1MB
+
+    /**
+     * Verify 1 MB of data for 10000 times (~ 10 GB in total)
+     */
+    public static void testVerifyLarge() {
+        Runtime runtime = Runtime.getRuntime();
+        long usedMemoryBefore = runtime.totalMemory() - runtime.freeMemory();
+        Instant t1 = Instant.now();
+
+        Random random = new Random();
+        for (int i = 1; i <= TIMES; i++) {
+            EdDSA eckey = new EdDSA();
+            byte[] data = new byte[SIZE];
+            random.nextBytes(data);
+            byte[] hash = Hash.h256(data);
+            byte[] sig = eckey.sign(hash).toBytes();
+
+            if (i % 1000 == 0) {
+                System.out.printf("...%d\n", i);
+            }
+
+            EdDSA.verify(hash, sig);
+        }
+
+        Instant t2 = Instant.now();
+        long usedMemoryAfter = runtime.totalMemory() - runtime.freeMemory();
+
+        logger.info("Perf_verify_large: {} bytes, took {}", usedMemoryAfter - usedMemoryBefore,
+                TimeUtil.formatDuration(Duration.between(t1, t2)));
+    }
+
+    public static void main(String[] args) throws Exception {
+        testVerifyLarge();
+    }
+}

--- a/src/test/java/org/semux/bench/CryptoPerformance.java
+++ b/src/test/java/org/semux/bench/CryptoPerformance.java
@@ -68,13 +68,17 @@ public class CryptoPerformance {
             byte[] hash = Hash.h256(data);
             byte[] sig = eckey.sign(hash).toBytes();
 
+            Runtime runtime = Runtime.getRuntime();
+            long usedMemoryBefore = runtime.totalMemory() - runtime.freeMemory();
             long t1 = System.nanoTime();
             for (int i = 0; i < REPEAT; i++) {
                 EdDSA.verify(hash, sig);
             }
             long t2 = System.nanoTime();
+            long usedMemoryAfter = runtime.totalMemory() - runtime.freeMemory();
 
-            logger.info("Perf_verify_{}k: {} μs/time", size / 1024, (t2 - t1) / 1_000 / REPEAT);
+            logger.info("Perf_verify_{}k: {} μs/time, {} bytes", size / 1024, (t2 - t1) / 1_000 / REPEAT,
+                    usedMemoryAfter - usedMemoryBefore);
         }
     }
 

--- a/src/test/java/org/semux/util/TimeUtilTest.java
+++ b/src/test/java/org/semux/util/TimeUtilTest.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2017 The Semux Developers
+ *
+ * Distributed under the MIT software license, see the accompanying file
+ * LICENSE or https://opensource.org/licenses/mit-license.php
+ */
+package org.semux.util;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.junit.Assert.assertTrue;
+
+@RunWith(Parameterized.class)
+public class TimeUtilTest {
+
+    @Parameterized.Parameters
+    public static Collection<Object[]> data() {
+        return Arrays
+                .asList(new Object[][] {
+                    {Duration.ofSeconds(86400), "24:00:00"},
+                    {Duration.ofSeconds(86400 - 1), "23:59:59"},
+                    {Duration.ofSeconds(0), "00:00:00"},
+                    {Duration.ofSeconds(-1), "00:00:-1"}
+                });
+    }
+
+    Duration duration;
+    String formatted;
+
+    public TimeUtilTest(Duration duration, String formatted) {
+        this.duration = duration;
+        this.formatted = formatted;
+    }
+
+    @Test
+    public void testFormatDuration() {
+        assertTrue(TimeUtil.formatDuration(duration).equals(formatted));
+    }
+}

--- a/src/test/java/org/semux/util/TimeUtilTest.java
+++ b/src/test/java/org/semux/util/TimeUtilTest.java
@@ -21,13 +21,9 @@ public class TimeUtilTest {
 
     @Parameterized.Parameters
     public static Collection<Object[]> data() {
-        return Arrays
-                .asList(new Object[][] {
-                    {Duration.ofSeconds(86400), "24:00:00"},
-                    {Duration.ofSeconds(86400 - 1), "23:59:59"},
-                    {Duration.ofSeconds(0), "00:00:00"},
-                    {Duration.ofSeconds(-1), "00:00:-1"}
-                });
+        return Arrays.asList(new Object[][] { { Duration.ofSeconds(86400), "24:00:00" },
+                { Duration.ofSeconds(86400 - 1), "23:59:59" }, { Duration.ofSeconds(0), "00:00:00" },
+                { Duration.ofSeconds(-1), "00:00:-1" } });
     }
 
     Duration duration;


### PR DESCRIPTION
### Motivation

According to profiling results, EdDSAPublicKey constructor consumes ~37% of CPU time of `EdDSAPublicKey::verify` mainly by [creating precomputed tables](https://github.com/str4d/ed25519-java/blob/master/src/net/i2p/crypto/eddsa/spec/EdDSAPublicKeySpec.java#L39). Considering that Semux has an infrequently changed list of validators, caching public keys can reduce the synchronization time significantly.

### Benchmark

The benchmark was running against the mainnet at the height of ~15K

#### Before 

![selection_419](https://user-images.githubusercontent.com/32390172/33391555-6c351df4-d574-11e7-8075-a065f863e7ef.png)

#### After

~42% saved CPU time on sync thread

![selection_418](https://user-images.githubusercontent.com/32390172/33391537-5ce19008-d574-11e7-8ab3-047fb271e634.png)
