### PR TITLE
API: do not reuse http handler instance

### DIFF
--- a/src/main/java/org/semux/api/HttpChannelInitializer.java
+++ b/src/main/java/org/semux/api/HttpChannelInitializer.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2017 The Semux Developers
+ *
+ * Distributed under the MIT software license, see the accompanying file
+ * LICENSE or https://opensource.org/licenses/mit-license.php
+ */
+package org.semux.api;
+
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.handler.codec.http.HttpRequestDecoder;
+import io.netty.handler.codec.http.HttpResponseEncoder;
+
+public abstract class HttpChannelInitializer extends ChannelInitializer<SocketChannel> {
+
+    @Override
+    public void initChannel(SocketChannel ch) {
+        ChannelPipeline p = ch.pipeline();
+        p.addLast(new HttpRequestDecoder());
+        p.addLast(new HttpResponseEncoder());
+        p.addLast(initHandler());
+    }
+
+    abstract HttpHandler initHandler();
+}

--- a/src/test/java/org/semux/api/HttpHandlerTest.java
+++ b/src/test/java/org/semux/api/HttpHandlerTest.java
@@ -44,13 +44,18 @@ public class HttpHandlerTest {
                 .encodeToString(Bytes.of(kernel.getConfig().apiUsername() + ":" + kernel.getConfig().apiPassword()));
 
         // wait for server to boot up
-        new Thread(() -> server.start(ip, port, new HttpHandler(kernel.getConfig(), (u, p, h) -> {
-            uri = u;
-            params = p;
-            headers = h;
+        new Thread(() -> server.start(ip, port, new HttpChannelInitializer() {
+            @Override
+            HttpHandler initHandler() {
+                return new HttpHandler(kernel.getConfig(), (u, p, h) -> {
+                    uri = u;
+                    params = p;
+                    headers = h;
 
-            return "test";
-        }))).start();
+                    return "test";
+                });
+            }
+        })).start();
         while (!server.isRunning()) {
             try {
                 Thread.sleep(200);


### PR DESCRIPTION
[A recent change](https://github.com/semuxproject/semux/commit/536469294e302f7a6b9b6c48b196c986615a5b80#diff-185beb24e446140927fa652e90b14e57L66) introduced an issue that SemuxAPI server is reusing a single instance of HttpHandler for all requests causing the following exception:

```
2017-12-04 15:43:42 [api-2] WARN  ChannelInitializer - Failed to initialize a channel. Closing: [id: 0x267cbe48, L:/127.0.0.1:5171 - R:/127.0.0.1:53482]
io.netty.channel.ChannelPipelineException: org.semux.api.HttpHandler is not a @Sharable handler, so can't be added or removed multiple times.
	at io.netty.channel.DefaultChannelPipeline.checkMultiplicity(DefaultChannelPipeline.java:588)
	at io.netty.channel.DefaultChannelPipeline.addLast(DefaultChannelPipeline.java:199)
	at io.netty.channel.DefaultChannelPipeline.addLast(DefaultChannelPipeline.java:392)
	at io.netty.channel.DefaultChannelPipeline.addLast(DefaultChannelPipeline.java:379)
	at org.semux.api.SemuxAPI$2.initChannel(SemuxAPI.java:78)
	at org.semux.api.SemuxAPI$2.initChannel(SemuxAPI.java:72)
	at io.netty.channel.ChannelInitializer.initChannel(ChannelInitializer.java:113)
	at io.netty.channel.ChannelInitializer.handlerAdded(ChannelInitializer.java:105)
	at io.netty.channel.DefaultChannelPipeline.callHandlerAdded0(DefaultChannelPipeline.java:597)
	at io.netty.channel.DefaultChannelPipeline.access$000(DefaultChannelPipeline.java:44)
	at io.netty.channel.DefaultChannelPipeline$PendingHandlerAddedTask.execute(DefaultChannelPipeline.java:1387)
	at io.netty.channel.DefaultChannelPipeline.callHandlerAddedForAllHandlers(DefaultChannelPipeline.java:1122)
	at io.netty.channel.DefaultChannelPipeline.invokeHandlerAddedIfNeeded(DefaultChannelPipeline.java:647)
	at io.netty.channel.AbstractChannel$AbstractUnsafe.register0(AbstractChannel.java:506)
	at io.netty.channel.AbstractChannel$AbstractUnsafe.access$200(AbstractChannel.java:419)
	at io.netty.channel.AbstractChannel$AbstractUnsafe$1.run(AbstractChannel.java:478)
	at io.netty.util.concurrent.AbstractEventExecutor.safeExecute$$$capture(AbstractEventExecutor.java:163)
	at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java)
	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:403)
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:462)
	at io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:858)
	at java.lang.Thread.run(Thread.java:748)
```