### PR TITLE
Enable multi-recipient transfer transaction

### DIFF
--- a/src/main/java/org/semux/api/ApiHandlerImpl.java
+++ b/src/main/java/org/semux/api/ApiHandlerImpl.java
@@ -9,11 +9,13 @@ package org.semux.api;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import org.apache.commons.lang3.StringUtils;
 import org.semux.Kernel;
 import org.semux.api.response.AddNodeResponse;
 import org.semux.api.response.CreateAccountResponse;
@@ -608,7 +610,7 @@ public class ApiHandlerImpl implements ApiHandler {
         try {
             TransactionBuilder transactionBuilder = new TransactionBuilder(kernel, type) //
                     .withFrom(params.get("from")) //
-                    .withTo(params.get("to")) //
+                    .withTo(Arrays.asList(StringUtils.split(params.getOrDefault("to", ""), ","))) //
                     .withValue(params.get("value")) //
                     .withFee(params.get("fee")) //
                     .withData(params.get("data"));

--- a/src/main/java/org/semux/api/response/GetTransactionResponse.java
+++ b/src/main/java/org/semux/api/response/GetTransactionResponse.java
@@ -7,7 +7,10 @@
 package org.semux.api.response;
 
 import java.text.SimpleDateFormat;
+import java.util.Arrays;
 import java.util.Date;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import org.semux.api.ApiHandlerResponse;
 import org.semux.core.Transaction;
@@ -40,7 +43,7 @@ public class GetTransactionResponse extends ApiHandlerResponse {
         public final String from;
 
         @JsonProperty("to")
-        public final String to;
+        public final List<String> to;
 
         @JsonProperty("value")
         public final Long value;
@@ -64,7 +67,7 @@ public class GetTransactionResponse extends ApiHandlerResponse {
                 @JsonProperty("hash") String hash, //
                 @JsonProperty("type") String type, //
                 @JsonProperty("from") String from, //
-                @JsonProperty("to") String to, //
+                @JsonProperty("to") List<String> to, //
                 @JsonProperty("value") Long value, //
                 @JsonProperty("fee") Long fee, //
                 @JsonProperty("nonce") Long nonce, //
@@ -85,16 +88,18 @@ public class GetTransactionResponse extends ApiHandlerResponse {
         }
 
         public Result(Transaction tx) {
-            this(Hex.encode0x(tx.getHash()), //
+            this(
+                    Hex.encode0x(tx.getHash()), //
                     tx.getType().toString(), //
                     Hex.encode0x(tx.getFrom()), //
-                    Hex.encode0x(tx.getTo()), //
+                    Arrays.stream(tx.getRecipients()).map(Hex::encode0x).collect(Collectors.toList()), //
                     tx.getValue(), //
                     tx.getFee(), //
                     tx.getNonce(), //
                     tx.getTimestamp(), //
                     new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(new Date(tx.getTimestamp())), //
-                    Hex.encode0x(tx.getData()));
+                    Hex.encode0x(tx.getData()) //
+            );
         }
     }
 }

--- a/src/main/java/org/semux/api/util/TransactionBuilder.java
+++ b/src/main/java/org/semux/api/util/TransactionBuilder.java
@@ -6,6 +6,9 @@
  */
 package org.semux.api.util;
 
+import java.util.List;
+
+import org.apache.commons.lang3.ArrayUtils;
 import org.semux.Kernel;
 import org.semux.core.Transaction;
 import org.semux.core.TransactionType;
@@ -76,22 +79,22 @@ public class TransactionBuilder {
         return this;
     }
 
-    public TransactionBuilder withTo(String toStr) {
+    public TransactionBuilder withTo(List<String> toList) {
         if (type == TransactionType.DELEGATE) {
-            if (toStr != null) {
+            if (toList != null && !toList.isEmpty()) {
                 throw new IllegalArgumentException("Parameter `to` is not needed for DELEGATE transaction");
             }
             return this; // ignore the provided parameter
         }
 
-        if (toStr == null) {
+        if (toList == null || toList.isEmpty()) {
             throw new IllegalArgumentException("Parameter `to` can't be null");
         }
 
         try {
-            this.to = Hex.decode0x(toStr);
+            this.to = toList.stream().map(String::trim).map(Hex::decode0x).reduce(new byte[0], ArrayUtils::addAll);
         } catch (CryptoException e) {
-            throw new IllegalArgumentException("Parameter `to` is not a valid hexadecimal string");
+            throw new IllegalArgumentException("Parameter 'to' contains invalid hexadecimal string");
         }
 
         return this;

--- a/src/main/java/org/semux/core/BlockchainImpl.java
+++ b/src/main/java/org/semux/core/BlockchainImpl.java
@@ -7,8 +7,10 @@
 package org.semux.core;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map.Entry;
+import java.util.stream.Stream;
 
 import org.apache.commons.lang3.tuple.Pair;
 import org.semux.config.Config;
@@ -275,7 +277,9 @@ public class BlockchainImpl implements Blockchain {
 
             // [3] update transaction_by_account index
             addTransactionToAccount(tx, tx.getFrom());
-            addTransactionToAccount(tx, tx.getTo());
+            Stream.of(tx.getRecipients())
+                    .filter(recipient -> !Arrays.equals(tx.getFrom(), recipient))
+                    .forEach(recipient -> addTransactionToAccount(tx, recipient));
         }
 
         if (number != genesis.getNumber()) {

--- a/src/main/java/org/semux/core/TransactionResult.java
+++ b/src/main/java/org/semux/core/TransactionResult.java
@@ -52,6 +52,11 @@ public class TransactionResult {
         INVALID_DATA_LENGTH,
 
         /**
+         * The number of recipients is invalid.
+         */
+        INVALID_NUMBER_OF_RECIPIENTS,
+
+        /**
          * Insufficient available balance.
          */
         INSUFFICIENT_AVAILABLE,

--- a/src/main/java/org/semux/core/exception/TransactionException.java
+++ b/src/main/java/org/semux/core/exception/TransactionException.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2017 The Semux Developers
+ *
+ * Distributed under the MIT software license, see the accompanying file
+ * LICENSE or https://opensource.org/licenses/mit-license.php
+ */
+package org.semux.core.exception;
+
+public class TransactionException extends RuntimeException {
+    public TransactionException() {
+    }
+
+    public TransactionException(String message) {
+        super(message);
+    }
+
+    public TransactionException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public TransactionException(Throwable cause) {
+        super(cause);
+    }
+
+    public TransactionException(String message, Throwable cause, boolean enableSuppression,
+            boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}

--- a/src/main/java/org/semux/gui/SwingUtil.java
+++ b/src/main/java/org/semux/gui/SwingUtil.java
@@ -19,11 +19,13 @@ import java.text.DateFormat;
 import java.text.NumberFormat;
 import java.text.ParseException;
 import java.text.ParsePosition;
+import java.util.Arrays;
 import java.util.Comparator;
 import java.util.Date;
 import java.util.EnumMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import javax.swing.ImageIcon;
 import javax.swing.JButton;
@@ -448,7 +450,7 @@ public class SwingUtil {
         switch (tx.getType()) {
         case COINBASE:
             return GUIMessages.get("BlockReward") + " => "
-                    + getDelegateName(gui, tx.getTo()).orElse(GUIMessages.get("UnknownDelegate"));
+                    + getDelegateName(gui, tx.getRecipient(0)).orElse(GUIMessages.get("UnknownDelegate"));
         case VOTE:
         case UNVOTE:
         case TRANSFER:
@@ -467,7 +469,11 @@ public class SwingUtil {
      * @return description of transaction with one or multiple recipients
      */
     private static String getTransactionRecipientsDescription(SemuxGUI gui, Transaction tx) {
-        return getAddressAlias(gui, tx.getFrom()) + " => " + getAddressAlias(gui, tx.getTo());
+        return getAddressAlias(gui, tx.getFrom()) + //
+                " => " + //
+                Arrays.stream(tx.getRecipients()) //
+                        .map(to -> getAddressAlias(gui, to)) //
+                        .collect(Collectors.joining(","));
     }
 
     /**

--- a/src/main/java/org/semux/gui/dialog/TransactionDialog.java
+++ b/src/main/java/org/semux/gui/dialog/TransactionDialog.java
@@ -6,6 +6,9 @@
  */
 package org.semux.gui.dialog;
 
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
 import javax.swing.GroupLayout;
 import javax.swing.GroupLayout.Alignment;
 import javax.swing.JDialog;
@@ -38,7 +41,9 @@ public class TransactionDialog extends JDialog {
         JTextArea hash = SwingUtil.textAreaWithCopyPastePopup(Hex.encode0x(tx.getHash()));
         JLabel type = new JLabel(tx.getType().name());
         JTextArea from = SwingUtil.textAreaWithCopyPastePopup(Hex.encode0x(tx.getFrom()));
-        JTextArea to = SwingUtil.textAreaWithCopyPastePopup(Hex.encode0x(tx.getTo()));
+        JTextArea to = SwingUtil
+                .textAreaWithCopyPastePopup(Arrays.stream(tx.getRecipients()).map(Hex::encode0x).collect(
+                        Collectors.joining(",")));
         JLabel value = new JLabel(SwingUtil.formatValue((tx.getValue())));
         JLabel fee = new JLabel(SwingUtil.formatValue((tx.getFee())));
         JLabel nonce = new JLabel(SwingUtil.formatNumber(tx.getNonce()));

--- a/src/main/java/org/semux/gui/panel/HomePanel.java
+++ b/src/main/java/org/semux/gui/panel/HomePanel.java
@@ -11,6 +11,7 @@ import java.awt.GridLayout;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
@@ -46,7 +47,8 @@ public class HomePanel extends JPanel implements ActionListener {
 
     private static final long serialVersionUID = 1L;
 
-    private static final EnumSet<TransactionType> FEDERATED_TRANSACTION_TYPES = EnumSet.of(TransactionType.COINBASE,
+    private static final EnumSet<TransactionType> FEDERATED_TRANSACTION_TYPES = EnumSet.of(
+            TransactionType.COINBASE,
             TransactionType.TRANSFER);
 
     private transient SemuxGUI gui;
@@ -174,7 +176,7 @@ public class HomePanel extends JPanel implements ActionListener {
             lblType.setIcon(SwingUtil.loadImage(name, 42, 42));
             String mathSign = inBound ? "+" : "-";
             String prefix = (inBound && outBound) ? "" : (mathSign);
-            JLabel lblAmount = new JLabel(prefix + SwingUtil.formatValue(tx.getValue()));
+            JLabel lblAmount = new JLabel(prefix + SwingUtil.formatValue(tx.getValue() * tx.numberOfRecipients()));
             lblAmount.setHorizontalAlignment(SwingConstants.RIGHT);
 
             JLabel lblTime = new JLabel(SwingUtil.formatTimestamp(tx.getTimestamp()));
@@ -262,7 +264,8 @@ public class HomePanel extends JPanel implements ActionListener {
         }
         transactions.removeAll();
         for (Transaction tx : list) {
-            boolean inBound = accounts.contains(ByteArray.of(tx.getTo()));
+            boolean inBound = accounts.stream().anyMatch(account -> Arrays.stream(tx.getRecipients())
+                    .anyMatch(recipient -> ByteArray.of(recipient).equals(account)));
             boolean outBound = accounts.contains(ByteArray.of(tx.getFrom()));
             transactions.add(new TransactionPanel(tx, inBound, outBound, SwingUtil.getTransactionDescription(gui, tx)));
         }

--- a/src/main/java/org/semux/gui/panel/TransactionsPanel.java
+++ b/src/main/java/org/semux/gui/panel/TransactionsPanel.java
@@ -149,7 +149,7 @@ public class TransactionsPanel extends JPanel implements ActionListener {
             case 1:
                 return SwingUtil.getTransactionDescription(gui, tx);
             case 2:
-                return SwingUtil.formatValue(tx.getValue());
+                return SwingUtil.formatValue(tx.getValue() * tx.numberOfRecipients());
             case 3:
                 return SwingUtil.formatTimestamp(tx.getTimestamp());
             default:

--- a/src/test/java/org/semux/KernelTest.java
+++ b/src/test/java/org/semux/KernelTest.java
@@ -7,16 +7,20 @@
 package org.semux;
 
 import static org.awaitility.Awaitility.await;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
+import java.time.Duration;
+import java.time.Instant;
 
 import org.junit.Rule;
 import org.junit.Test;
 import org.semux.integration.KernelTestRule;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class KernelTest {
+
+    private Logger logger = LoggerFactory.getLogger(KernelTest.class);
 
     @Rule
     public KernelTestRule kernelRule = new KernelTestRule(15160, 15170);
@@ -29,29 +33,31 @@ public class KernelTest {
         Kernel kernel = kernelRule.getKernelMock();
 
         // start kernel
+        Instant begin = Instant.now();
         kernel.start();
-        await().until(kernel::isRunning);
-
-        assertTrue(kernel.getNodeManager().isRunning());
-        assertTrue(kernel.getPendingManager().isRunning());
-
-        assertTrue(kernel.getApi().isRunning());
-        assertTrue(kernel.getP2p().isRunning());
-
-        assertTrue(kernel.getConsensus().isRunning());
-        assertFalse(kernel.getSyncManager().isRunning());
+        await().until(() -> //
+        kernel.isRunning() && //
+                kernel.getNodeManager().isRunning() && //
+                kernel.getPendingManager().isRunning() && //
+                kernel.getApi().isRunning() && //
+                kernel.getP2p().isRunning() && //
+                kernel.getConsensus().isRunning() && //
+                !kernel.getSyncManager().isRunning() //
+        );
+        logger.info("Kernel successfully started after {} ms", Duration.between(begin, Instant.now()).toMillis());
 
         // stop kernel
+        begin = Instant.now();
         kernel.stop();
-        await().until(() -> !kernel.isRunning());
-
-        assertFalse(kernel.getNodeManager().isRunning());
-        assertFalse(kernel.getPendingManager().isRunning());
-
-        assertFalse(kernel.getApi().isRunning());
-        assertFalse(kernel.getP2p().isRunning());
-
-        assertFalse(kernel.getConsensus().isRunning());
-        assertFalse(kernel.getSyncManager().isRunning());
+        await().until(() -> //
+        !kernel.isRunning() && //
+                !kernel.getNodeManager().isRunning() && //
+                !kernel.getPendingManager().isRunning() && //
+                !kernel.getApi().isRunning() && //
+                !kernel.getP2p().isRunning() && //
+                !kernel.getConsensus().isRunning() && //
+                !kernel.getSyncManager().isRunning() //
+        );
+        logger.info("Kernel successfully stopped after {} ms", Duration.between(begin, Instant.now()).toMillis());
     }
 }

--- a/src/test/java/org/semux/api/ApiHandlerTestBase.java
+++ b/src/test/java/org/semux/api/ApiHandlerTestBase.java
@@ -110,4 +110,19 @@ public abstract class ApiHandlerTestBase {
 
         return tx;
     }
+
+    protected Transaction createTransactionToMany(int numberOfRecipients) {
+        TransactionType type = TransactionType.TRANSFER;
+        byte[] to = Bytes.random(EdDSA.ADDRESS_LEN * numberOfRecipients);
+        long value = 0;
+        long fee = 0;
+        long nonce = 1;
+        long timestamp = System.currentTimeMillis();
+        byte[] data = {};
+
+        Transaction tx = new Transaction(type, to, value, fee, nonce, timestamp, data);
+        tx.sign(new EdDSA());
+
+        return tx;
+    }
 }

--- a/src/test/java/org/semux/api/util/TransactionBuilderTest.java
+++ b/src/test/java/org/semux/api/util/TransactionBuilderTest.java
@@ -8,11 +8,15 @@ package org.semux.api.util;
 
 import static org.mockito.Mockito.mock;
 
+import java.util.ArrayList;
+import java.util.Collections;
+
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.semux.Kernel;
 import org.semux.core.TransactionType;
+import org.semux.crypto.EdDSA;
 
 public class TransactionBuilderTest {
 
@@ -22,12 +26,25 @@ public class TransactionBuilderTest {
     @Test
     public void testDelegateWithTo() {
         expectedException.expect(IllegalArgumentException.class);
-        new TransactionBuilder(mock(Kernel.class), TransactionType.DELEGATE).withTo("0xabc");
+        new TransactionBuilder(mock(Kernel.class), TransactionType.DELEGATE)
+                .withTo(Collections.singletonList(new EdDSA().toAddressString()));
     }
 
     @Test
     public void testDelegateWithValue() {
         expectedException.expect(IllegalArgumentException.class);
         new TransactionBuilder(mock(Kernel.class), TransactionType.DELEGATE).withValue("10");
+    }
+
+    @Test
+    public void testTransferWithoutTo() {
+        expectedException.expect(IllegalArgumentException.class);
+        new TransactionBuilder(mock(Kernel.class), TransactionType.TRANSFER).withTo(new ArrayList<>());
+    }
+
+    @Test
+    public void testTransferWithTo() {
+        new TransactionBuilder(mock(Kernel.class), TransactionType.TRANSFER)
+                .withTo(Collections.singletonList(new EdDSA().toAddressString()));
     }
 }

--- a/src/test/java/org/semux/bench/BlockchainPerformance.java
+++ b/src/test/java/org/semux/bench/BlockchainPerformance.java
@@ -45,7 +45,8 @@ public class BlockchainPerformance {
     private static final long timestamp = System.currentTimeMillis() - 60 * 1000;
 
     /**
-     * The benchmark tries to create a block filled with single-recipient TRANSFER transactions
+     * The benchmark tries to create a block filled with single-recipient TRANSFER
+     * transactions
      */
     private static void testLargeBlockSingleRecipient(DBFactory dbFactory) {
         logger.info("Binary-searching the maximum number of single-recipient transactions per block...");
@@ -57,7 +58,7 @@ public class BlockchainPerformance {
 
         int low = 1, high = config.maxBlockSize() / EdDSA.ADDRESS_LEN, numberOfTxs = (low + high) / 2;
         Block block = makeSingleRecipientBlock(numberOfTxs);
-        while(high - low > 1) {
+        while (high - low > 1) {
             System.out.format("low = %d, mid = %d, high = %d\n", low, numberOfTxs, high);
 
             if (block.size() > config.maxBlockSize()) {
@@ -72,14 +73,15 @@ public class BlockchainPerformance {
         blockchain.addBlock(block);
         Duration duration = Duration.between(begin, Instant.now());
 
-        logger.info("Single-Recipient Block Size = {} bytes, {} txs, took {}\n", block.size(), numberOfTxs, TimeUtil.formatDuration(duration));
+        logger.info("Single-Recipient Block Size = {} bytes, {} txs, took {}\n", block.size(), numberOfTxs,
+                TimeUtil.formatDuration(duration));
     }
 
     private static Block makeSingleRecipientBlock(int numberOfTxs) {
         List<Transaction> txs = new ArrayList<>();
         List<TransactionResult> results = new ArrayList<>();
 
-        for (int i = 0;i < numberOfTxs;i++) {
+        for (int i = 0; i < numberOfTxs; i++) {
             txs.add(new Transaction(TransactionType.TRANSFER, Bytes.random(EdDSA.ADDRESS_LEN), value, fee,
                     nonce + numberOfTxs, timestamp, data).sign(key));
             results.add(new TransactionResult(true));
@@ -93,7 +95,8 @@ public class BlockchainPerformance {
     }
 
     /**
-     * The benchmark tries to create a block filled with multi-recipient TRANSFER transactions
+     * The benchmark tries to create a block filled with multi-recipient TRANSFER
+     * transactions
      */
     private static void testLargeBlockMultiRecipients(DBFactory dbFactory) {
         logger.info("Binary-searching the maximum number of recipients per block...");
@@ -105,7 +108,7 @@ public class BlockchainPerformance {
 
         int low = 1, high = config.maxBlockSize() / EdDSA.ADDRESS_LEN, numberOfRecipients = (low + high) / 2;
         Block block = makeMultiRecipientBlock(numberOfRecipients);
-        while(high - low > 1) {
+        while (high - low > 1) {
             System.out.format("low = %d, mid = %d, high = %d\n", low, numberOfRecipients, high);
 
             if (block.size() > config.maxBlockSize()) {
@@ -120,11 +123,13 @@ public class BlockchainPerformance {
         blockchain.addBlock(block);
         Duration duration = Duration.between(begin, Instant.now());
 
-        logger.info("Multi-Recipient Block Size = {} bytes, {} recipients, took {}\n", block.size(), numberOfRecipients, TimeUtil.formatDuration(duration));
+        logger.info("Multi-Recipient Block Size = {} bytes, {} recipients, took {}\n", block.size(), numberOfRecipients,
+                TimeUtil.formatDuration(duration));
     }
 
     private static Block makeMultiRecipientBlock(int numberOfRecipients) {
-        Transaction tx = new Transaction(TransactionType.TRANSFER, Bytes.random(numberOfRecipients * EdDSA.ADDRESS_LEN), value, fee,
+        Transaction tx = new Transaction(TransactionType.TRANSFER, Bytes.random(numberOfRecipients * EdDSA.ADDRESS_LEN),
+                value, fee,
                 nonce + numberOfRecipients, timestamp, data).sign(key);
         List<TransactionResult> results = Arrays.asList(new TransactionResult(true));
         List<Transaction> txs = Arrays.asList(tx);

--- a/src/test/java/org/semux/core/BlockchainImplTest.java
+++ b/src/test/java/org/semux/core/BlockchainImplTest.java
@@ -129,7 +129,7 @@ public class BlockchainImplTest {
         Transaction t = chain.getTransaction(tx.getHash());
         assertNotNull(t);
         assertTrue(Arrays.equals(from, t.getFrom()));
-        assertTrue(Arrays.equals(to, t.getTo()));
+        assertTrue(Arrays.equals(to, t.getRecipient(0)));
         assertTrue(Arrays.equals(data, t.getData()));
         assertTrue(t.getValue() == value);
         assertTrue(t.getNonce() == nonce);

--- a/src/test/java/org/semux/core/TransactionExecutorTest.java
+++ b/src/test/java/org/semux/core/TransactionExecutorTest.java
@@ -90,6 +90,79 @@ public class TransactionExecutorTest {
     }
 
     @Test
+    public void testTransferMany() {
+        EdDSA key = new EdDSA();
+        final int numberOfRecipients = 2;
+
+        TransactionType type = TransactionType.TRANSFER;
+        byte[] from = key.toAddress();
+        byte[] to = Bytes.random(EdDSA.ADDRESS_LEN * numberOfRecipients);
+        long value = 5;
+        long fee = config.minTransactionFee() * 2;
+        long nonce = as.getAccount(from).getNonce();
+        long timestamp = System.currentTimeMillis();
+        byte[] data = Bytes.random(16);
+
+        Transaction tx = new Transaction(type, to, value, fee, nonce, timestamp, data);
+        byte[][] recipients = tx.getRecipients();
+        tx.sign(key);
+        assertTrue(tx.validate());
+
+        // insufficient available
+        TransactionResult result = exec.execute(tx, as.track(), ds.track());
+        assertFalse(result.isSuccess());
+
+        long available = 1000 * Unit.SEM;
+        as.adjustAvailable(key.toAddress(), available);
+
+        // execute but not commit
+        result = exec.execute(tx, as.track(), ds.track());
+        assertTrue(result.isSuccess());
+        assertEquals(available, as.getAccount(key.toAddress()).getAvailable());
+        assertEquals(0, as.getAccount(recipients[0]).getAvailable());
+        assertEquals(0, as.getAccount(recipients[1]).getAvailable());
+
+        // execute and commit
+        result = executeAndCommit(exec, tx, as.track(), ds.track());
+        assertTrue(result.isSuccess());
+        assertEquals(available - value * numberOfRecipients - fee, as.getAccount(key.toAddress()).getAvailable());
+        assertEquals(value, as.getAccount(recipients[0]).getAvailable());
+        assertEquals(value, as.getAccount(recipients[1]).getAvailable());
+    }
+
+    @Test
+    public void testTransferManyLowFee() {
+        EdDSA key = new EdDSA();
+        final int numberOfRecipients = 2;
+
+        TransactionType type = TransactionType.TRANSFER;
+        byte[] from = key.toAddress();
+        byte[] to = Bytes.random(EdDSA.ADDRESS_LEN * numberOfRecipients);
+        long value = 5;
+        long fee = config.minTransactionFee();
+        long nonce = as.getAccount(from).getNonce();
+        long timestamp = System.currentTimeMillis();
+        byte[] data = Bytes.random(16);
+
+        Transaction tx = new Transaction(type, to, value, fee, nonce, timestamp, data);
+        tx.sign(key);
+        assertTrue(tx.validate());
+
+        // insufficient available
+        TransactionResult result = exec.execute(tx, as.track(), ds.track());
+        assertFalse(result.isSuccess());
+
+        long available = 1000 * Unit.SEM;
+        as.adjustAvailable(key.toAddress(), available);
+
+        // execution should be failed
+        result = exec.execute(tx, as.track(), ds.track());
+        assertFalse(
+                "transaction with a fee lower than 'number of recipients * minimum fee' should be rejected",
+                result.isSuccess());
+    }
+
+    @Test
     public void testDelegate() {
         EdDSA delegate = new EdDSA();
 

--- a/src/test/java/org/semux/core/TransactionTest.java
+++ b/src/test/java/org/semux/core/TransactionTest.java
@@ -8,10 +8,16 @@ package org.semux.core;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import java.util.ArrayList;
+import java.util.EnumSet;
+
+import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.RandomUtils;
 import org.junit.Test;
 import org.semux.config.Config;
 import org.semux.config.Constants;
@@ -63,10 +69,62 @@ public class TransactionTest {
         logger.info("tx size: {} B, {} GB per 1M txs", bytes.length, 1000000.0 * bytes.length / 1024 / 1024 / 1024);
     }
 
+    @Test
+    public void testGetRecipients() {
+        Transaction tx = new Transaction(TransactionType.TRANSFER, Bytes.random(EdDSA.ADDRESS_LEN * 10), value,
+                fee, nonce, timestamp, Bytes.EMPTY_BYTES).sign(key);
+        byte[][] recipients = tx.getRecipients();
+        assertEquals(10, recipients.length);
+        for (byte[] recipient : recipients) {
+            assertEquals(EdDSA.ADDRESS_LEN, recipient.length);
+        }
+    }
+
+    @Test
+    public void testGetRecipient() {
+        ArrayList<EdDSA> recipients = new ArrayList<>();
+        int numberOfRecipients = RandomUtils.nextInt(1, 200);
+        for (int i = 0; i < numberOfRecipients; i++) {
+            recipients.add(new EdDSA());
+        }
+
+        Transaction tx = new Transaction(
+                TransactionType.TRANSFER,
+                recipients.stream().map(EdDSA::toAddress).reduce(new byte[0], ArrayUtils::addAll),
+                value,
+                fee,
+                nonce,
+                timestamp,
+                Bytes.EMPTY_BYTES);
+
+        for (int i = 0; i < numberOfRecipients; i++) {
+            assertArrayEquals(recipients.get(i).toAddress(), tx.getRecipient(i));
+        }
+    }
+
+    @Test
+    public void testValidateMultiRecipientException() {
+        EnumSet<TransactionType> transactionTypes = EnumSet.allOf(TransactionType.class);
+        transactionTypes.remove(TransactionType.TRANSFER);
+        for (TransactionType type : transactionTypes) {
+            Transaction tx = new Transaction(
+                    type,
+                    Bytes.random(EdDSA.ADDRESS_LEN * 2),
+                    value,
+                    fee,
+                    nonce,
+                    timestamp,
+                    Bytes.EMPTY_BYTES);
+            assertFalse(
+                    "TRANSFER should be the only transaction type that supports multiple recipients",
+                    tx.validate());
+        }
+    }
+
     private void testFields(Transaction tx) {
         assertEquals(type, tx.getType());
         assertArrayEquals(key.toAddress(), tx.getFrom());
-        assertArrayEquals(to, tx.getTo());
+        assertArrayEquals(to, tx.getRecipient(0));
         assertEquals(value, tx.getValue());
         assertEquals(fee, tx.getFee());
         assertEquals(nonce, tx.getNonce());

--- a/src/test/java/org/semux/db/LevelDBTest.java
+++ b/src/test/java/org/semux/db/LevelDBTest.java
@@ -23,13 +23,18 @@ import org.iq80.leveldb.DBException;
 import org.iq80.leveldb.Options;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.semux.config.Constants;
 import org.semux.db.LevelDB.LevelDBFactory;
 import org.semux.util.Bytes;
 import org.semux.util.ClosableIterator;
 
 public class LevelDBTest {
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
     private byte[] key = Bytes.of("key");
     private byte[] value = Bytes.of("value");
@@ -38,17 +43,18 @@ public class LevelDBTest {
 
     @Before
     public void setup() {
-        db = new LevelDB(new File(Constants.DEFAULT_DATA_DIR, Constants.DATABASE_DIR + File.separator + "test"));
+        db = new LevelDB(temporaryFolder.getRoot());
     }
 
     @After
     public void teardown() {
-        db.close();
+        db.destroy();
     }
 
     @Test
     public void testRecover() {
         Options options = db.createOptions();
+        db.close();
         db.recover(options);
     }
 

--- a/src/test/java/org/semux/gui/panel/SendPanelTest.java
+++ b/src/test/java/org/semux/gui/panel/SendPanelTest.java
@@ -59,9 +59,12 @@ public class SendPanelTest {
         window.show();
 
         // fill form
-        EdDSA recipient = new EdDSA();
-        window.textBox("toText").setText(Hex.encode0x(recipient.toAddress()));
+        EdDSA recipient1 = new EdDSA();
+        EdDSA recipient2 = new EdDSA();
+        window.textBox("toText")
+                .setText(Hex.encode0x(recipient1.toAddress()) + "," + Hex.encode0x(recipient2.toAddress()));
         window.textBox("amountText").setText("100");
+        window.textBox("feeText").setText("0.10");
         window.button("sendButton").click();
 
         // a confirmation dialog should be displayed
@@ -74,9 +77,12 @@ public class SendPanelTest {
         verify(pendingManager).addTransactionSync(transactionArgumentCaptor.capture());
         Transaction tx = transactionArgumentCaptor.getValue();
         assertEquals(TransactionType.TRANSFER, tx.getType());
-        assertArrayEquals(recipient.toAddress(), tx.getTo());
+
+        assertEquals(2, tx.numberOfRecipients());
+        assertArrayEquals(recipient1.toAddress(), tx.getRecipient(0));
+        assertArrayEquals(recipient2.toAddress(), tx.getRecipient(1));
         assertEquals(100 * Unit.SEM, tx.getValue());
-        assertEquals(application.kernelMock.getConfig().minTransactionFee(), tx.getFee());
+        assertEquals(application.kernelMock.getConfig().minTransactionFee() * 2, tx.getFee());
 
         // clean up
         window.cleanUp();


### PR DESCRIPTION
The feature enables batch-payment with up to 100K recipients per block.

**Benchmark result of BlockchainPerformance.java**

- Single-Recipient Block Size = 2097128 bytes, 8961 txs (1 recipient)
- Multi-Recipient Block Size = 2097148 bytes, 104834 recipients (1 tx)