### PR TITLE
Util: replace ipify with opendns

### DIFF
--- a/src/main/java/org/semux/util/SystemUtil.java
+++ b/src/main/java/org/semux/util/SystemUtil.java
@@ -6,20 +6,22 @@
  */
 package org.semux.util;
 
-import java.io.BufferedReader;
 import java.io.Console;
-import java.io.InputStreamReader;
 import java.net.InetAddress;
-import java.net.URL;
-import java.net.URLConnection;
+import java.net.InetSocketAddress;
 import java.util.Scanner;
+import java.util.concurrent.ExecutionException;
 
-import org.semux.config.Constants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.github.zafarkhaja.semver.Version;
 
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.nio.NioDatagramChannel;
+import io.netty.resolver.dns.DnsNameResolver;
+import io.netty.resolver.dns.DnsNameResolverBuilder;
+import io.netty.resolver.dns.SequentialDnsServerAddressStreamProvider;
 import oshi.SystemInfo;
 
 public class SystemUtil {
@@ -77,28 +79,27 @@ public class SystemUtil {
     }
 
     /**
-     * Returns the public IP address of this peer.
+     * Returns the public IP address of this peer by querying opendns.
      * 
      * @return an IP address if available, otherwise local address
      */
     public static String getIp() {
         try {
-            URL url = new URL("http://api.ipify.org/");
-            URLConnection con = url.openConnection();
-            con.addRequestProperty("User-Agent", Constants.DEFAULT_USER_AGENT);
-            con.setConnectTimeout(Constants.DEFAULT_CONNECT_TIMEOUT);
-            con.setReadTimeout(Constants.DEFAULT_READ_TIMEOUT);
-
-            BufferedReader reader = new BufferedReader(new InputStreamReader(con.getInputStream()));
-            String ip = reader.readLine().trim();
-            reader.close();
-
-            // only IPv4 is supported currently
-            if (ip.matches("(\\d{1,3}\\.){3}\\d{1,3}")) {
-                return ip;
-            }
-        } catch (Exception e) {
-            logger.error("Failed to retrieve your IP address from ipify.org");
+            DnsNameResolver nameResolver = new DnsNameResolverBuilder(new NioEventLoopGroup().next())
+                    .channelType(NioDatagramChannel.class)
+                    .queryTimeoutMillis(1000)
+                    .nameServerProvider(new SequentialDnsServerAddressStreamProvider(
+                            new InetSocketAddress("208.67.222.222", 53),
+                            new InetSocketAddress("208.67.220.220", 53),
+                            new InetSocketAddress("208.67.222.220", 53),
+                            new InetSocketAddress("208.67.220.222", 53)))
+                    .build();
+            return nameResolver.resolve("myip.opendns.com").await().get().getHostAddress();
+        } catch (ExecutionException e) {
+            logger.error("Failed to retrieve your IP address from opendns", e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            logger.error("Failed to retrieve your IP address from opendns", e);
         }
 
         try {

--- a/src/test/java/org/semux/util/SystemUtilTest.java
+++ b/src/test/java/org/semux/util/SystemUtilTest.java
@@ -10,6 +10,9 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 
+import java.time.Duration;
+import java.time.Instant;
+
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -28,10 +31,12 @@ public class SystemUtilTest {
 
     @Test
     public void testGetIp() {
+        Instant begin = Instant.now();
         String ip = SystemUtil.getIp();
         logger.info("IP address = {}", ip);
         assertNotNull(ip);
         assertFalse(ip.equals("127.0.0.1"));
+        logger.info("SystemUtil.getIp took {} ms", Duration.between(begin, Instant.now()).toMillis());
     }
 
     @Test


### PR DESCRIPTION
Retrieve public IP by looking up `myip.opendns.com` on [opendns](https://en.wikipedia.org/wiki/OpenDNS) enables network redundancy of SystemUtil::getIp and reduces the chance of issues like #336  