### PR TITLE
Allow Flaky Tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ matrix:
       script:
         - mvn license:check
         - mvn formatter:validate
-        - mvn cobertura:cobertura
+        - mvn -Djava.awt.headless=false cobertura:cobertura
       after_success:
         - mvn coveralls:report
 
@@ -16,12 +16,8 @@ matrix:
     - os: linux
       sudo: false
       jdk: oraclejdk8
-      addons:
-        apt:
-          packages:
-            - oracle-java8-installer
       script:
-        - mvn test
+        - mvn -Djava.awt.headless=false test
 
     # macOS tests
     - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ matrix:
     - os: osx
       osx_image: xcode9.2
       script:
-        - mvn test
+        - mvn -Djava.awt.headless=false test
 
     # Docker tests
     - language: none
@@ -36,12 +36,6 @@ matrix:
         - docker run -d -p 5161:5161 semux:latest --password=""
         - timeout 10 .travis/docker_test_build.sh
         - docker kill $(docker ps -q)
-
-    # OSX Testing
-    - os: osx
-      osx_image: xcode9.2
-      script:
-        - mvn -Djava.awt.headless=false test
 cache:
   directories:
     - .autoconf

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,13 @@ matrix:
         - docker run -d -p 5161:5161 semux:latest --password=""
         - timeout 10 .travis/docker_test_build.sh
         - docker kill $(docker ps -q)
+
+    # OSX Testing
+    - os: osx
+      osx_image: xcode9.2
+      script:
+        - mvn test
+
 cache:
   directories:
     - .autoconf

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,8 +45,7 @@ matrix:
     - os: osx
       osx_image: xcode9.2
       script:
-        - mvn test
-
+        - mvn -Djava.awt.headless=false test
 cache:
   directories:
     - .autoconf

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,7 @@ cache:
   directories:
     - .autoconf
     - $HOME/.m2
+    - $HOME/Library/Caches/Homebrew
 before_install:
   - if [ "$TRAVIS_OS_NAME" == "linux" ]; then source .travis/linux_start_xvfb.sh; fi
   - if [ "$TRAVIS_OS_NAME" == "osx" ]; then .travis/macos_install_jdk8.sh; fi

--- a/.travis/start_xvfb.sh
+++ b/.travis/start_xvfb.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+export DISPLAY=:99.0
+/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1920x1080x16

--- a/.travis/start_xvfb.sh
+++ b/.travis/start_xvfb.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-
-export DISPLAY=:99.0
-/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1920x1080x16

--- a/pom.xml
+++ b/pom.xml
@@ -263,6 +263,7 @@
                     <!-- do not reuse forks of JVM in order to avoid random fails on travis -->
                     <forkCount>1</forkCount>
                     <reuseForks>false</reuseForks>
+                    <rerunFailingTestsCount>1</rerunFailingTestsCount>
                 </configuration>
             </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -260,10 +260,11 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.20.1</version>
                 <configuration>
-                    <!-- do not reuse forks of JVM in order to avoid random fails on travis -->
+                    <!-- do not reuse JVM instances -->
                     <forkCount>1</forkCount>
                     <reuseForks>false</reuseForks>
-                    <rerunFailingTestsCount>1</rerunFailingTestsCount>
+                    <!-- allow flaky tests -->
+                    <rerunFailingTestsCount>2</rerunFailingTestsCount>
                 </configuration>
             </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -253,6 +253,18 @@
                     </directories>
                 </configuration>
             </plugin>
+
+            <!-- testing -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.20.1</version>
+                <configuration>
+                    <!-- do not reuse forks of JVM in order to avoid random fails on travis -->
+                    <forkCount>1</forkCount>
+                    <reuseForks>false</reuseForks>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/src/main/java/org/semux/gui/panel/ReceivePanel.java
+++ b/src/main/java/org/semux/gui/panel/ReceivePanel.java
@@ -73,6 +73,7 @@ public class ReceivePanel extends JPanel implements ActionListener {
 
         tableModel = new ReceiveTableModel();
         table = new JTable(tableModel);
+        table.setName("accountsTable");
         table.setBackground(Color.WHITE);
         table.setFillsViewportHeight(true);
         table.setGridColor(Color.LIGHT_GRAY);

--- a/src/test/java/org/semux/gui/panel/DelegatePanelTest.java
+++ b/src/test/java/org/semux/gui/panel/DelegatePanelTest.java
@@ -89,8 +89,6 @@ public class DelegatePanelTest extends AssertJSwingJUnitTestCase {
 
     KernelMock kernelMock;
 
-    DelegatePanelTestApplication application;
-
     @Override
     public void onSetUp() {
         // mock delegates

--- a/src/test/java/org/semux/gui/panel/DelegatePanelTest.java
+++ b/src/test/java/org/semux/gui/panel/DelegatePanelTest.java
@@ -14,14 +14,16 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.awt.Point;
 import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.commons.lang3.RandomUtils;
+import org.assertj.swing.annotation.GUITest;
+import org.assertj.swing.annotation.RunsInEDT;
 import org.assertj.swing.edt.GuiActionRunner;
 import org.assertj.swing.fixture.FrameFixture;
-import org.junit.After;
-import org.junit.Before;
+import org.assertj.swing.junit.testcase.AssertJSwingJUnitTestCase;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -47,7 +49,7 @@ import org.semux.rules.KernelRule;
 import junit.framework.TestCase;
 
 @RunWith(MockitoJUnitRunner.class)
-public class DelegatePanelTest {
+public class DelegatePanelTest extends AssertJSwingJUnitTestCase {
 
     @Rule
     public KernelRule kernelRule1 = new KernelRule(51610, 51710);
@@ -91,8 +93,10 @@ public class DelegatePanelTest {
 
     KernelMock kernelMock;
 
-    @Before
-    public void setUp() {
+    DelegatePanelTestApplication application;
+
+    @Override
+    public void onSetUp() {
         // mock delegates
         walletDelegates = new ArrayList<>();
 
@@ -119,20 +123,20 @@ public class DelegatePanelTest {
         when(kernelMock.getBlockchain()).thenReturn(blockchain);
     }
 
-    @After
-    public void tearDown() {
-        window.cleanUp();
-        application.dispose();
+    @Override
+    public void onTearDown() {
         Mockito.reset(kernelMock);
     }
 
     @Test
+    @GUITest
+    @RunsInEDT
     public void testSelectDelegate() {
         when(kernelMock.getPendingManager()).thenReturn(pendingManager);
         application = GuiActionRunner
                 .execute(() -> new DelegatePanelTestApplication(walletRule.walletModel, kernelMock));
-        window = new FrameFixture(application);
-        window.show().requireVisible();
+        window = new FrameFixture(robot(), application);
+        window.show().requireVisible().moveTo(new Point(0, 0)).moveToFront();
 
         // the initial label of selected delegate should be PleaseSelectDelegate
         window.label("SelectedDelegateLabel").requireText(GUIMessages.get("PleaseSelectDelegate"));
@@ -151,6 +155,8 @@ public class DelegatePanelTest {
     }
 
     @Test
+    @GUITest
+    @RunsInEDT
     public void testVoteSuccess() {
         testVote(new PendingManager.ProcessTransactionResult(1));
 
@@ -159,6 +165,8 @@ public class DelegatePanelTest {
     }
 
     @Test
+    @GUITest
+    @RunsInEDT
     public void testVoteFailure() {
         testVote(new PendingManager.ProcessTransactionResult(0, TransactionResult.Error.INSUFFICIENT_AVAILABLE));
 
@@ -173,8 +181,8 @@ public class DelegatePanelTest {
         when(kernelMock.getPendingManager()).thenReturn(pendingManager);
         application = GuiActionRunner
                 .execute(() -> new DelegatePanelTestApplication(walletRule.walletModel, kernelMock));
-        window = new FrameFixture(application);
-        window.show();
+        window = new FrameFixture(robot(), application);
+        window.show().requireVisible().moveTo(new Point(0, 0)).moveToFront();
 
         // the initial label of selected delegate should be PleaseSelectDelegate
         window.label("SelectedDelegateLabel").requireText(GUIMessages.get("PleaseSelectDelegate"));
@@ -190,6 +198,8 @@ public class DelegatePanelTest {
     }
 
     @Test
+    @GUITest
+    @RunsInEDT
     public void testDelegateSuccess() {
         testDelegate(new PendingManager.ProcessTransactionResult(1));
 
@@ -206,6 +216,8 @@ public class DelegatePanelTest {
     }
 
     @Test
+    @GUITest
+    @RunsInEDT
     public void testDelegateFailure() {
         testDelegate(new PendingManager.ProcessTransactionResult(0, TransactionResult.Error.INSUFFICIENT_AVAILABLE));
 
@@ -220,8 +232,8 @@ public class DelegatePanelTest {
         when(kernelMock.getPendingManager()).thenReturn(pendingManager);
         application = GuiActionRunner
                 .execute(() -> new DelegatePanelTestApplication(walletRule.walletModel, kernelMock));
-        window = new FrameFixture(application);
-        window.show().requireVisible();
+        window = new FrameFixture(robot(), application);
+        window.show().requireVisible().moveTo(new Point(0, 0)).moveToFront();
 
         // fills delegate name
         window.textBox("textName").requireEditable().setText("test_delegate");

--- a/src/test/java/org/semux/gui/panel/DelegatePanelTest.java
+++ b/src/test/java/org/semux/gui/panel/DelegatePanelTest.java
@@ -6,20 +6,16 @@
  */
 package org.semux.gui.panel;
 
-import static org.assertj.swing.core.matcher.JButtonMatcher.withText;
 import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.awt.Point;
 import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.commons.lang3.RandomUtils;
-import org.assertj.swing.annotation.GUITest;
 import org.assertj.swing.annotation.RunsInEDT;
 import org.assertj.swing.edt.GuiActionRunner;
 import org.assertj.swing.fixture.FrameFixture;
@@ -135,7 +131,7 @@ public class DelegatePanelTest extends AssertJSwingJUnitTestCase {
         application = GuiActionRunner
                 .execute(() -> new DelegatePanelTestApplication(walletRule.walletModel, kernelMock));
         window = new FrameFixture(robot(), application);
-        window.show().requireVisible().moveTo(new Point(0, 0)).moveToFront();
+        window.show().requireVisible().moveToFront();
 
         // the initial label of selected delegate should be PleaseSelectDelegate
         window.label("SelectedDelegateLabel").requireText(GUIMessages.get("PleaseSelectDelegate"));
@@ -157,18 +153,14 @@ public class DelegatePanelTest extends AssertJSwingJUnitTestCase {
     @RunsInEDT
     public void testVoteSuccess() {
         testVote(new PendingManager.ProcessTransactionResult(1));
-
-        window.dialog().requireVisible();
-        assertEquals(GUIMessages.get("SuccessDialogTitle"), window.dialog().target().getTitle());
+        window.optionPane().requireTitle(GUIMessages.get("SuccessDialogTitle")).requireVisible();
     }
 
     @Test
     @RunsInEDT
     public void testVoteFailure() {
         testVote(new PendingManager.ProcessTransactionResult(0, TransactionResult.Error.INSUFFICIENT_AVAILABLE));
-
-        window.dialog().requireVisible();
-        assertEquals(GUIMessages.get("ErrorDialogTitle"), window.dialog().target().getTitle());
+        window.optionPane().requireTitle(GUIMessages.get("ErrorDialogTitle")).requireVisible();
     }
 
     private void testVote(PendingManager.ProcessTransactionResult mockResult) {
@@ -179,7 +171,7 @@ public class DelegatePanelTest extends AssertJSwingJUnitTestCase {
         application = GuiActionRunner
                 .execute(() -> new DelegatePanelTestApplication(walletRule.walletModel, kernelMock));
         window = new FrameFixture(robot(), application);
-        window.show().requireVisible().moveTo(new Point(0, 0)).moveToFront();
+        window.show().requireVisible().moveToFront();
 
         // the initial label of selected delegate should be PleaseSelectDelegate
         window.label("SelectedDelegateLabel").requireText(GUIMessages.get("PleaseSelectDelegate"));
@@ -198,9 +190,7 @@ public class DelegatePanelTest extends AssertJSwingJUnitTestCase {
     @RunsInEDT
     public void testDelegateSuccess() {
         testDelegate(new PendingManager.ProcessTransactionResult(1));
-
-        window.dialog().requireVisible();
-        assertEquals(GUIMessages.get("SuccessDialogTitle"), window.dialog().target().getTitle());
+        window.optionPane().requireTitle(GUIMessages.get("SuccessDialogTitle")).requireVisible();
 
         // verify added transaction
         verify(pendingManager).addTransactionSync(transactionArgumentCaptor.capture());
@@ -215,9 +205,7 @@ public class DelegatePanelTest extends AssertJSwingJUnitTestCase {
     @RunsInEDT
     public void testDelegateFailure() {
         testDelegate(new PendingManager.ProcessTransactionResult(0, TransactionResult.Error.INSUFFICIENT_AVAILABLE));
-
-        window.dialog().requireVisible();
-        assertEquals(GUIMessages.get("ErrorDialogTitle"), window.dialog().target().getTitle());
+        window.optionPane().requireTitle(GUIMessages.get("ErrorDialogTitle")).requireVisible();
     }
 
     private void testDelegate(PendingManager.ProcessTransactionResult mockResult) {
@@ -228,7 +216,7 @@ public class DelegatePanelTest extends AssertJSwingJUnitTestCase {
         application = GuiActionRunner
                 .execute(() -> new DelegatePanelTestApplication(walletRule.walletModel, kernelMock));
         window = new FrameFixture(robot(), application);
-        window.show().requireVisible().moveTo(new Point(0, 0)).moveToFront();
+        window.show().requireVisible().moveToFront();
 
         // fills delegate name
         window.textBox("textName").requireEditable().setText("test_delegate");
@@ -237,6 +225,7 @@ public class DelegatePanelTest extends AssertJSwingJUnitTestCase {
         window.button("btnDelegate").requireVisible().click();
 
         // confirm
-        window.dialog().requireVisible().button(withText("Yes")).requireVisible().click();
+        window.optionPane().requireTitle(GUIMessages.get("ConfirmDelegateRegistration")).requireVisible()
+                .yesButton().requireVisible().click();
     }
 }

--- a/src/test/java/org/semux/gui/panel/DelegatePanelTest.java
+++ b/src/test/java/org/semux/gui/panel/DelegatePanelTest.java
@@ -129,7 +129,6 @@ public class DelegatePanelTest extends AssertJSwingJUnitTestCase {
     }
 
     @Test
-    @GUITest
     @RunsInEDT
     public void testSelectDelegate() {
         when(kernelMock.getPendingManager()).thenReturn(pendingManager);
@@ -155,7 +154,6 @@ public class DelegatePanelTest extends AssertJSwingJUnitTestCase {
     }
 
     @Test
-    @GUITest
     @RunsInEDT
     public void testVoteSuccess() {
         testVote(new PendingManager.ProcessTransactionResult(1));
@@ -165,7 +163,6 @@ public class DelegatePanelTest extends AssertJSwingJUnitTestCase {
     }
 
     @Test
-    @GUITest
     @RunsInEDT
     public void testVoteFailure() {
         testVote(new PendingManager.ProcessTransactionResult(0, TransactionResult.Error.INSUFFICIENT_AVAILABLE));
@@ -198,7 +195,6 @@ public class DelegatePanelTest extends AssertJSwingJUnitTestCase {
     }
 
     @Test
-    @GUITest
     @RunsInEDT
     public void testDelegateSuccess() {
         testDelegate(new PendingManager.ProcessTransactionResult(1));
@@ -216,7 +212,6 @@ public class DelegatePanelTest extends AssertJSwingJUnitTestCase {
     }
 
     @Test
-    @GUITest
     @RunsInEDT
     public void testDelegateFailure() {
         testDelegate(new PendingManager.ProcessTransactionResult(0, TransactionResult.Error.INSUFFICIENT_AVAILABLE));

--- a/src/test/java/org/semux/gui/panel/DelegatePanelTest.java
+++ b/src/test/java/org/semux/gui/panel/DelegatePanelTest.java
@@ -16,10 +16,10 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.commons.lang3.RandomUtils;
-import org.assertj.swing.annotation.RunsInEDT;
 import org.assertj.swing.edt.GuiActionRunner;
 import org.assertj.swing.fixture.FrameFixture;
 import org.assertj.swing.junit.testcase.AssertJSwingJUnitTestCase;
+import org.assertj.swing.timing.Timeout;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -125,7 +125,6 @@ public class DelegatePanelTest extends AssertJSwingJUnitTestCase {
     }
 
     @Test
-    @RunsInEDT
     public void testSelectDelegate() {
         when(kernelMock.getPendingManager()).thenReturn(pendingManager);
         application = GuiActionRunner
@@ -150,17 +149,15 @@ public class DelegatePanelTest extends AssertJSwingJUnitTestCase {
     }
 
     @Test
-    @RunsInEDT
     public void testVoteSuccess() {
         testVote(new PendingManager.ProcessTransactionResult(1));
-        window.optionPane().requireTitle(GUIMessages.get("SuccessDialogTitle")).requireVisible();
+        window.optionPane(Timeout.timeout(1000)).requireTitle(GUIMessages.get("SuccessDialogTitle")).requireVisible();
     }
 
     @Test
-    @RunsInEDT
     public void testVoteFailure() {
         testVote(new PendingManager.ProcessTransactionResult(0, TransactionResult.Error.INSUFFICIENT_AVAILABLE));
-        window.optionPane().requireTitle(GUIMessages.get("ErrorDialogTitle")).requireVisible();
+        window.optionPane(Timeout.timeout(1000)).requireTitle(GUIMessages.get("ErrorDialogTitle")).requireVisible();
     }
 
     private void testVote(PendingManager.ProcessTransactionResult mockResult) {
@@ -187,10 +184,9 @@ public class DelegatePanelTest extends AssertJSwingJUnitTestCase {
     }
 
     @Test
-    @RunsInEDT
     public void testDelegateSuccess() {
         testDelegate(new PendingManager.ProcessTransactionResult(1));
-        window.optionPane().requireTitle(GUIMessages.get("SuccessDialogTitle")).requireVisible();
+        window.optionPane(Timeout.timeout(1000)).requireTitle(GUIMessages.get("SuccessDialogTitle")).requireVisible();
 
         // verify added transaction
         verify(pendingManager).addTransactionSync(transactionArgumentCaptor.capture());
@@ -202,10 +198,9 @@ public class DelegatePanelTest extends AssertJSwingJUnitTestCase {
     }
 
     @Test
-    @RunsInEDT
     public void testDelegateFailure() {
         testDelegate(new PendingManager.ProcessTransactionResult(0, TransactionResult.Error.INSUFFICIENT_AVAILABLE));
-        window.optionPane().requireTitle(GUIMessages.get("ErrorDialogTitle")).requireVisible();
+        window.optionPane(Timeout.timeout(1000)).requireTitle(GUIMessages.get("ErrorDialogTitle")).requireVisible();
     }
 
     private void testDelegate(PendingManager.ProcessTransactionResult mockResult) {
@@ -225,7 +220,8 @@ public class DelegatePanelTest extends AssertJSwingJUnitTestCase {
         window.button("btnDelegate").requireVisible().click();
 
         // confirm
-        window.optionPane().requireTitle(GUIMessages.get("ConfirmDelegateRegistration")).requireVisible()
+        window.optionPane(Timeout.timeout(1000)).requireTitle(GUIMessages.get("ConfirmDelegateRegistration"))
+                .requireVisible()
                 .yesButton().requireVisible().click();
     }
 }

--- a/src/test/java/org/semux/gui/panel/HomePanelTest.java
+++ b/src/test/java/org/semux/gui/panel/HomePanelTest.java
@@ -11,7 +11,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
-import org.assertj.swing.annotation.RunsInEDT;
 import org.assertj.swing.edt.GuiActionRunner;
 import org.assertj.swing.fixture.FrameFixture;
 import org.assertj.swing.junit.testcase.AssertJSwingJUnitTestCase;
@@ -37,7 +36,6 @@ public class HomePanelTest extends AssertJSwingJUnitTestCase {
     WalletModel walletModel;
 
     @Test
-    @RunsInEDT
     public void testSyncProgress100() {
         // mock progress
         SemuxSync.SemuxSyncProgress progress = new SemuxSync.SemuxSyncProgress(100L, 100L);
@@ -62,7 +60,6 @@ public class HomePanelTest extends AssertJSwingJUnitTestCase {
     }
 
     @Test
-    @RunsInEDT
     public void testProgressFormatter() {
         assertEquals(GUIMessages.get("SyncFinished"),
                 HomePanel.SyncProgressFormatter.format(new SemuxSync.SemuxSyncProgress(100L, 100L)));

--- a/src/test/java/org/semux/gui/panel/HomePanelTest.java
+++ b/src/test/java/org/semux/gui/panel/HomePanelTest.java
@@ -11,9 +11,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
-import java.awt.Point;
-
-import org.assertj.swing.annotation.GUITest;
 import org.assertj.swing.annotation.RunsInEDT;
 import org.assertj.swing.edt.GuiActionRunner;
 import org.assertj.swing.fixture.FrameFixture;
@@ -55,7 +52,7 @@ public class HomePanelTest extends AssertJSwingJUnitTestCase {
                 .execute(() -> new HomePanelTestApplication(walletModel, kernelMock));
 
         FrameFixture window = new FrameFixture(robot(), application);
-        window.show().requireVisible().moveTo(new Point(0, 0)).moveToFront();
+        window.show().requireVisible().moveToFront();
 
         window.requireVisible();
         window.label("syncProgress").requireText(HomePanel.SyncProgressFormatter.format(progress));

--- a/src/test/java/org/semux/gui/panel/HomePanelTest.java
+++ b/src/test/java/org/semux/gui/panel/HomePanelTest.java
@@ -11,8 +11,13 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
+import java.awt.Point;
+
+import org.assertj.swing.annotation.GUITest;
+import org.assertj.swing.annotation.RunsInEDT;
 import org.assertj.swing.edt.GuiActionRunner;
 import org.assertj.swing.fixture.FrameFixture;
+import org.assertj.swing.junit.testcase.AssertJSwingJUnitTestCase;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -26,7 +31,7 @@ import org.semux.message.GUIMessages;
 import org.semux.rules.KernelRule;
 
 @RunWith(MockitoJUnitRunner.class)
-public class HomePanelTest {
+public class HomePanelTest extends AssertJSwingJUnitTestCase {
 
     @Rule
     public KernelRule kernelRule1 = new KernelRule(51610, 51710);
@@ -35,6 +40,8 @@ public class HomePanelTest {
     WalletModel walletModel;
 
     @Test
+    @GUITest
+    @RunsInEDT
     public void testSyncProgress100() {
         // mock progress
         SemuxSync.SemuxSyncProgress progress = new SemuxSync.SemuxSyncProgress(100L, 100L);
@@ -48,8 +55,8 @@ public class HomePanelTest {
         HomePanelTestApplication application = GuiActionRunner
                 .execute(() -> new HomePanelTestApplication(walletModel, kernelMock));
 
-        FrameFixture window = new FrameFixture(application);
-        window.show();
+        FrameFixture window = new FrameFixture(robot(), application);
+        window.show().requireVisible().moveTo(new Point(0, 0)).moveToFront();
 
         window.requireVisible();
         window.label("syncProgress").requireText(HomePanel.SyncProgressFormatter.format(progress));
@@ -59,6 +66,8 @@ public class HomePanelTest {
     }
 
     @Test
+    @GUITest
+    @RunsInEDT
     public void testProgressFormatter() {
         assertEquals(GUIMessages.get("SyncFinished"),
                 HomePanel.SyncProgressFormatter.format(new SemuxSync.SemuxSyncProgress(100L, 100L)));
@@ -67,5 +76,10 @@ public class HomePanelTest {
         assertEquals(GUIMessages.get("SyncStopped"),
                 HomePanel.SyncProgressFormatter.format(new SemuxSync.SemuxSyncProgress(100L, 0L)));
         assertEquals(GUIMessages.get("SyncStopped"), HomePanel.SyncProgressFormatter.format(null));
+    }
+
+    @Override
+    protected void onSetUp() {
+
     }
 }

--- a/src/test/java/org/semux/gui/panel/HomePanelTest.java
+++ b/src/test/java/org/semux/gui/panel/HomePanelTest.java
@@ -40,7 +40,6 @@ public class HomePanelTest extends AssertJSwingJUnitTestCase {
     WalletModel walletModel;
 
     @Test
-    @GUITest
     @RunsInEDT
     public void testSyncProgress100() {
         // mock progress
@@ -66,7 +65,6 @@ public class HomePanelTest extends AssertJSwingJUnitTestCase {
     }
 
     @Test
-    @GUITest
     @RunsInEDT
     public void testProgressFormatter() {
         assertEquals(GUIMessages.get("SyncFinished"),

--- a/src/test/java/org/semux/gui/panel/ReceivePanelTest.java
+++ b/src/test/java/org/semux/gui/panel/ReceivePanelTest.java
@@ -46,7 +46,8 @@ public class ReceivePanelTest extends AssertJSwingJUnitTestCase {
 
     FrameFixture window;
 
-    @Override protected void onSetUp() {
+    @Override
+    protected void onSetUp() {
 
     }
 

--- a/src/test/java/org/semux/gui/panel/ReceivePanelTest.java
+++ b/src/test/java/org/semux/gui/panel/ReceivePanelTest.java
@@ -6,14 +6,25 @@
  */
 package org.semux.gui.panel;
 
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
+import java.awt.Point;
+import java.awt.Toolkit;
+import java.awt.datatransfer.Clipboard;
+import java.awt.datatransfer.DataFlavor;
+import java.awt.datatransfer.UnsupportedFlavorException;
+import java.io.IOException;
+import java.io.StringReader;
 import java.util.Arrays;
 
+import org.apache.commons.io.IOUtils;
+import org.assertj.swing.annotation.GUITest;
+import org.assertj.swing.annotation.RunsInEDT;
 import org.assertj.swing.edt.GuiActionRunner;
 import org.assertj.swing.fixture.FrameFixture;
-import org.junit.After;
+import org.assertj.swing.junit.testcase.AssertJSwingJUnitTestCase;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -29,7 +40,7 @@ import org.semux.message.GUIMessages;
 import org.semux.rules.KernelRule;
 
 @RunWith(MockitoJUnitRunner.class)
-public class ReceivePanelTest {
+public class ReceivePanelTest extends AssertJSwingJUnitTestCase {
 
     @Rule
     public KernelRule kernelRule1 = new KernelRule(51610, 51710);
@@ -41,14 +52,14 @@ public class ReceivePanelTest {
 
     FrameFixture window;
 
-    @After
-    public void tearDown() {
-        window.cleanUp();
-        application.dispose();
+    @Override protected void onSetUp() {
+
     }
 
     @Test
-    public void testCopyAddress() {
+    @GUITest
+    @RunsInEDT
+    public void testCopyAddress() throws IOException, UnsupportedFlavorException {
         EdDSA key1 = new EdDSA();
         EdDSA key2 = new EdDSA();
         WalletAccount acc1 = new WalletAccount(key1, new Account(key1.toAddress(), 1, 1, 1));
@@ -61,11 +72,13 @@ public class ReceivePanelTest {
         KernelMock kernelMock = spy(kernelRule1.getKernel());
         application = GuiActionRunner.execute(() -> new ReceivePanelTestApplication(walletModel, kernelMock));
 
-        window = new FrameFixture(application);
-        window.show().requireVisible();
+        window = new FrameFixture(robot(), application);
+        window.show().requireVisible().moveTo(new Point(0, 0)).moveToFront();
 
-        window.table().selectRows(1);
+        window.table().requireVisible().selectRows(1);
         window.button("btnCopyAddress").requireVisible().click();
+        assertEquals(Hex.PREF + key2.toAddressString(),
+                Toolkit.getDefaultToolkit().getSystemClipboard().getData(DataFlavor.stringFlavor));
         window.dialog().requireVisible().optionPane()
                 .requireMessage(GUIMessages.get("AddressCopied", Hex.PREF + key2.toAddressString()));
     }

--- a/src/test/java/org/semux/gui/panel/ReceivePanelTest.java
+++ b/src/test/java/org/semux/gui/panel/ReceivePanelTest.java
@@ -74,7 +74,8 @@ public class ReceivePanelTest extends AssertJSwingJUnitTestCase {
         window = new FrameFixture(robot(), application);
         window.show().requireVisible().moveTo(new Point(0, 0)).moveToFront();
 
-        window.table().requireVisible().selectRows(1).requireSelectedRows(1);
+        window.table().cell(Hex.PREF + key2.toAddressString()).requireNotEditable().click();
+        window.table().requireSelectedRows(1);
         window.button("btnCopyAddress").requireVisible().click();
         assertEquals(Hex.PREF + key2.toAddressString(),
                 Toolkit.getDefaultToolkit().getSystemClipboard().getData(DataFlavor.stringFlavor));

--- a/src/test/java/org/semux/gui/panel/ReceivePanelTest.java
+++ b/src/test/java/org/semux/gui/panel/ReceivePanelTest.java
@@ -57,7 +57,6 @@ public class ReceivePanelTest extends AssertJSwingJUnitTestCase {
     }
 
     @Test
-    @GUITest
     @RunsInEDT
     public void testCopyAddress() throws IOException, UnsupportedFlavorException {
         EdDSA key1 = new EdDSA();

--- a/src/test/java/org/semux/gui/panel/ReceivePanelTest.java
+++ b/src/test/java/org/semux/gui/panel/ReceivePanelTest.java
@@ -75,7 +75,7 @@ public class ReceivePanelTest extends AssertJSwingJUnitTestCase {
         window = new FrameFixture(robot(), application);
         window.show().requireVisible().moveTo(new Point(0, 0)).moveToFront();
 
-        window.table().requireVisible().selectRows(1);
+        window.table().requireVisible().selectRows(1).requireSelectedRows(1);
         window.button("btnCopyAddress").requireVisible().click();
         assertEquals(Hex.PREF + key2.toAddressString(),
                 Toolkit.getDefaultToolkit().getSystemClipboard().getData(DataFlavor.stringFlavor));

--- a/src/test/java/org/semux/gui/panel/ReceivePanelTest.java
+++ b/src/test/java/org/semux/gui/panel/ReceivePanelTest.java
@@ -12,15 +12,13 @@ import static org.mockito.Mockito.when;
 
 import java.awt.Toolkit;
 import java.awt.datatransfer.DataFlavor;
-import java.awt.datatransfer.UnsupportedFlavorException;
-import java.io.IOException;
 import java.util.Arrays;
 
-import org.assertj.swing.annotation.RunsInEDT;
 import org.assertj.swing.edt.GuiActionRunner;
 import org.assertj.swing.fixture.FrameFixture;
 import org.assertj.swing.fixture.JTableFixture;
 import org.assertj.swing.junit.testcase.AssertJSwingJUnitTestCase;
+import org.assertj.swing.timing.Timeout;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -53,8 +51,7 @@ public class ReceivePanelTest extends AssertJSwingJUnitTestCase {
     }
 
     @Test
-    @RunsInEDT
-    public void testCopyAddress() throws IOException, UnsupportedFlavorException, InterruptedException {
+    public void testCopyAddress() {
         EdDSA key1 = new EdDSA();
         EdDSA key2 = new EdDSA();
         WalletAccount acc1 = new WalletAccount(key1, new Account(key1.toAddress(), 1, 1, 1));
@@ -76,7 +73,7 @@ public class ReceivePanelTest extends AssertJSwingJUnitTestCase {
         window.button("btnCopyAddress").requireVisible().click();
         assertEquals(Hex.PREF + key2.toAddressString(), GuiActionRunner
                 .execute(() -> Toolkit.getDefaultToolkit().getSystemClipboard().getData(DataFlavor.stringFlavor)));
-        window.optionPane().requireVisible()
+        window.optionPane(Timeout.timeout(1000)).requireVisible()
                 .requireMessage(GUIMessages.get("AddressCopied", Hex.PREF + key2.toAddressString()));
     }
 }

--- a/src/test/java/org/semux/gui/panel/SendPanelTest.java
+++ b/src/test/java/org/semux/gui/panel/SendPanelTest.java
@@ -72,14 +72,17 @@ public class SendPanelTest extends AssertJSwingJUnitTestCase {
     @Test
     @GUITest
     @RunsInEDT
-    public void testSendSuccessfully() {
+    public void testSendSuccessfully() throws InterruptedException {
         testSend(100, new PendingManager.ProcessTransactionResult(1));
 
         // 1. a confirmation dialog should be displayed
-        window.dialog().requireVisible().button(withText("Yes")).requireVisible().click();
+        window.dialog().requireVisible().moveToFront();
+        assertEquals(GUIMessages.get("ConfirmTransfer"), window.dialog().target().getTitle());
 
         // 2. filled transaction should be sent to PendingManager once "Yes" button is
         // clicked
+        window.button(withText("Yes")).requireEnabled().requireVisible().click();
+        window.dialog().requireVisible();
         assertEquals(GUIMessages.get("SuccessDialogTitle"), window.dialog().target().getTitle());
         verify(pendingManager).addTransactionSync(transactionArgumentCaptor.capture());
 
@@ -94,7 +97,7 @@ public class SendPanelTest extends AssertJSwingJUnitTestCase {
     @Test
     @GUITest
     @RunsInEDT
-    public void testSendFailure() {
+    public void testSendFailure() throws InterruptedException {
         testSend(10000, new PendingManager.ProcessTransactionResult(0, TransactionResult.Error.INSUFFICIENT_AVAILABLE));
         window.dialog().requireVisible();
         assertEquals(GUIMessages.get("ErrorDialogTitle"), window.dialog().target().getTitle());
@@ -114,8 +117,10 @@ public class SendPanelTest extends AssertJSwingJUnitTestCase {
         window.show().requireVisible().moveTo(new Point(0, 0)).moveToFront();
 
         // fill form
-        window.textBox("toText").requireEditable().setText(Hex.encode0x(recipient.toAddress()));
-        window.textBox("amountText").requireEditable().setText(String.valueOf(toSendSEM));
+        window.textBox("toText").requireEditable().setText(Hex.encode0x(recipient.toAddress()))
+                .requireText(Hex.encode0x(recipient.toAddress()));
+        window.textBox("amountText").requireEditable().setText(String.valueOf(toSendSEM))
+                .requireText(String.valueOf(toSendSEM));
         window.button("sendButton").requireVisible().click();
     }
 }

--- a/src/test/java/org/semux/gui/panel/SendPanelTest.java
+++ b/src/test/java/org/semux/gui/panel/SendPanelTest.java
@@ -6,7 +6,6 @@
  */
 package org.semux.gui.panel;
 
-import static org.assertj.swing.core.matcher.JButtonMatcher.withText;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
@@ -15,10 +14,10 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import org.apache.commons.lang3.RandomUtils;
-import org.assertj.swing.annotation.RunsInEDT;
 import org.assertj.swing.edt.GuiActionRunner;
 import org.assertj.swing.fixture.FrameFixture;
 import org.assertj.swing.junit.testcase.AssertJSwingJUnitTestCase;
+import org.assertj.swing.timing.Timeout;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -73,17 +72,17 @@ public class SendPanelTest extends AssertJSwingJUnitTestCase {
     }
 
     @Test
-    @RunsInEDT
-    public void testSendSuccessfully() throws InterruptedException {
+    public void testSendSuccessfully() {
         testSend(100, new PendingManager.ProcessTransactionResult(1));
 
         // 1. a confirmation dialog should be displayed
-        window.optionPane().requireTitle(GUIMessages.get("ConfirmTransfer")).requireVisible()
-                .button(withText("Yes")).requireVisible().click();
+        window.optionPane(Timeout.timeout(1000)).requireTitle(GUIMessages.get("ConfirmTransfer")).requireVisible()
+                .yesButton().requireVisible().click();
 
         // 2. filled transaction should be sent to PendingManager once "Yes" button is
         // clicked
-        window.optionPane().requireTitle(GUIMessages.get("SuccessDialogTitle")).requireVisible();
+        window.optionPane(Timeout.timeout(1000)).requireTitle(GUIMessages.get("SuccessDialogTitle")).requireVisible()
+                .okButton().requireVisible().click();
         verify(pendingManager).addTransactionSync(transactionArgumentCaptor.capture());
 
         // verify transaction
@@ -95,10 +94,9 @@ public class SendPanelTest extends AssertJSwingJUnitTestCase {
     }
 
     @Test
-    @RunsInEDT
-    public void testSendFailure() throws InterruptedException {
+    public void testSendFailure() {
         testSend(10000, new PendingManager.ProcessTransactionResult(0, TransactionResult.Error.INSUFFICIENT_AVAILABLE));
-        window.optionPane().requireTitle(GUIMessages.get("ErrorDialogTitle"));
+        window.optionPane(Timeout.timeout(1000)).requireTitle(GUIMessages.get("ErrorDialogTitle"));
     }
 
     private void testSend(int toSendSEM, PendingManager.ProcessTransactionResult mockResult) {

--- a/src/test/java/org/semux/gui/panel/SendPanelTest.java
+++ b/src/test/java/org/semux/gui/panel/SendPanelTest.java
@@ -70,7 +70,6 @@ public class SendPanelTest extends AssertJSwingJUnitTestCase {
     }
 
     @Test
-    @GUITest
     @RunsInEDT
     public void testSendSuccessfully() throws InterruptedException {
         testSend(100, new PendingManager.ProcessTransactionResult(1));
@@ -95,7 +94,6 @@ public class SendPanelTest extends AssertJSwingJUnitTestCase {
     }
 
     @Test
-    @GUITest
     @RunsInEDT
     public void testSendFailure() throws InterruptedException {
         testSend(10000, new PendingManager.ProcessTransactionResult(0, TransactionResult.Error.INSUFFICIENT_AVAILABLE));

--- a/src/test/java/org/semux/gui/panel/SendPanelTest.java
+++ b/src/test/java/org/semux/gui/panel/SendPanelTest.java
@@ -14,11 +14,14 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.awt.Point;
+
 import org.apache.commons.lang3.RandomUtils;
+import org.assertj.swing.annotation.GUITest;
+import org.assertj.swing.annotation.RunsInEDT;
 import org.assertj.swing.edt.GuiActionRunner;
 import org.assertj.swing.fixture.FrameFixture;
-import org.junit.After;
-import org.junit.Before;
+import org.assertj.swing.junit.testcase.AssertJSwingJUnitTestCase;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -39,7 +42,7 @@ import org.semux.message.GUIMessages;
 import org.semux.rules.KernelRule;
 
 @RunWith(MockitoJUnitRunner.class)
-public class SendPanelTest {
+public class SendPanelTest extends AssertJSwingJUnitTestCase {
 
     @Rule
     public KernelRule kernelRule1 = new KernelRule(51610, 51710);
@@ -61,18 +64,14 @@ public class SendPanelTest {
 
     KernelMock kernelMock;
 
-    @Before
-    public void setUp() {
+    @Override
+    protected void onSetUp() {
         recipient = new EdDSA();
     }
 
-    @After
-    public void tearDown() {
-        window.cleanUp();
-        application.dispose();
-    }
-
     @Test
+    @GUITest
+    @RunsInEDT
     public void testSendSuccessfully() {
         testSend(100, new PendingManager.ProcessTransactionResult(1));
 
@@ -93,6 +92,8 @@ public class SendPanelTest {
     }
 
     @Test
+    @GUITest
+    @RunsInEDT
     public void testSendFailure() {
         testSend(10000, new PendingManager.ProcessTransactionResult(0, TransactionResult.Error.INSUFFICIENT_AVAILABLE));
         window.dialog().requireVisible();
@@ -109,11 +110,10 @@ public class SendPanelTest {
         when(kernelMock.getPendingManager()).thenReturn(pendingManager);
 
         // create window
-        window = new FrameFixture(application);
-        window.show();
+        window = new FrameFixture(robot(), application);
+        window.show().requireVisible().moveTo(new Point(0, 0)).moveToFront();
 
         // fill form
-        window.requireVisible();
         window.textBox("toText").requireEditable().setText(Hex.encode0x(recipient.toAddress()));
         window.textBox("amountText").requireEditable().setText(String.valueOf(toSendSEM));
         window.button("sendButton").requireVisible().click();


### PR DESCRIPTION
For some reason GUI tests are failing randomly on Travis-CI. Enabling `rerunFailingTestsCount` of surefire plugin can help us get rid of failing builds for now.

Flaky tests will be reported as the following image:
![selection_462](https://user-images.githubusercontent.com/32390172/34347534-23bc25ba-ea3f-11e7-876e-4a526da83ecb.png)
