### PR TITLE
Reject Transactions With Duplicated Hash

### DIFF
--- a/src/main/java/org/semux/consensus/SemuxBFT.java
+++ b/src/main/java/org/semux/consensus/SemuxBFT.java
@@ -746,6 +746,10 @@ public class SemuxBFT implements Consensus {
             logger.debug("Invalid block transactions");
             return false;
         }
+        if (transactions.stream().anyMatch(tx -> chain.hasTransaction(tx.getHash()))) {
+            logger.debug("Duplicated transaction detected");
+            return false;
+        }
 
         AccountState as = accountState.track();
         DelegateState ds = delegateState.track();

--- a/src/main/java/org/semux/consensus/SemuxBFT.java
+++ b/src/main/java/org/semux/consensus/SemuxBFT.java
@@ -747,7 +747,7 @@ public class SemuxBFT implements Consensus {
             return false;
         }
         if (transactions.stream().anyMatch(tx -> chain.hasTransaction(tx.getHash()))) {
-            logger.debug("Duplicated transaction detected");
+            logger.warn("Duplicated transaction hash is not allowed");
             return false;
         }
 

--- a/src/main/java/org/semux/consensus/SemuxSync.java
+++ b/src/main/java/org/semux/consensus/SemuxSync.java
@@ -316,10 +316,16 @@ public class SemuxSync implements SyncManager {
      * @param block
      * @return
      */
-    private boolean validateApplyBlock(Block block) {
+    protected boolean validateApplyBlock(Block block) {
+        AccountState as = chain.getAccountState().track();
+        DelegateState ds = chain.getDelegateState().track();
+
+        return validateBlock(block, as, ds) && applyBlock(block, as, ds);
+    }
+
+    protected boolean validateBlock(Block block, AccountState asSnapshot, DelegateState dsSnapshot) {
         BlockHeader header = block.getHeader();
         List<Transaction> transactions = block.getTransactions();
-        long number = header.getNumber();
 
         // [1] check block header
         Block latest = chain.getLatestBlock();
@@ -338,13 +344,15 @@ public class SemuxSync implements SyncManager {
             logger.debug("Invalid results");
             return false;
         }
+        if (transactions.stream().anyMatch(tx -> chain.hasTransaction(tx.getHash()))) {
+            logger.debug("Duplicated transaction detected");
+            return false;
+        }
 
-        AccountState as = chain.getAccountState().track();
-        DelegateState ds = chain.getDelegateState().track();
         TransactionExecutor transactionExecutor = new TransactionExecutor(config);
 
         // [3] evaluate transactions
-        List<TransactionResult> results = transactionExecutor.execute(transactions, as, ds);
+        List<TransactionResult> results = transactionExecutor.execute(transactions, asSnapshot, dsSnapshot);
         if (!Block.validateResults(header, results)) {
             logger.debug("Invalid transactions");
             return false;
@@ -359,7 +367,8 @@ public class SemuxSync implements SyncManager {
         }
 
         Set<String> set = new HashSet<>(validators);
-        Vote vote = new Vote(VoteType.PRECOMMIT, Vote.VALUE_APPROVE, number, block.getView(), block.getHash());
+        Vote vote = new Vote(VoteType.PRECOMMIT, Vote.VALUE_APPROVE, block.getNumber(), block.getView(),
+                block.getHash());
         byte[] encoded = vote.getEncoded();
         for (Signature sig : block.getVotes()) {
             String a = Hex.encode(sig.getAddress());
@@ -370,18 +379,22 @@ public class SemuxSync implements SyncManager {
             }
         }
 
+        return true;
+    }
+
+    protected boolean applyBlock(Block block, AccountState asSnapshot, DelegateState dsSnapshot) {
         // [5] apply block reward and tx fees
-        long reward = config.getBlockReward(number);
+        long reward = config.getBlockReward(block.getNumber());
         for (Transaction tx : block.getTransactions()) {
             reward += tx.getFee();
         }
         if (reward > 0) {
-            as.adjustAvailable(block.getCoinbase(), reward);
+            asSnapshot.adjustAvailable(block.getCoinbase(), reward);
         }
 
         // [6] commit the updates
-        as.commit();
-        ds.commit();
+        asSnapshot.commit();
+        dsSnapshot.commit();
 
         WriteLock writeLock = kernel.getStateLock().writeLock();
         writeLock.lock();

--- a/src/main/java/org/semux/core/Blockchain.java
+++ b/src/main/java/org/semux/core/Blockchain.java
@@ -91,6 +91,14 @@ public interface Blockchain {
     Transaction getTransaction(byte[] hash);
 
     /**
+     * Returns whether the transaction is in the blockchain.
+     *
+     * @param hash
+     * @return
+     */
+    boolean hasTransaction(byte[] hash);
+
+    /**
      * Returns transaction result.
      * 
      * @param hash

--- a/src/main/java/org/semux/core/BlockchainImpl.java
+++ b/src/main/java/org/semux/core/BlockchainImpl.java
@@ -207,6 +207,11 @@ public class BlockchainImpl implements Blockchain {
     }
 
     @Override
+    public boolean hasTransaction(final byte[] hash) {
+        return indexDB.get(Bytes.merge(TYPE_TRANSACTION_HASH, hash)) != null;
+    }
+
+    @Override
     public TransactionResult getTransactionResult(byte[] hash) {
         byte[] bytes = indexDB.get(Bytes.merge(TYPE_TRANSACTION_HASH, hash));
         if (bytes != null) {

--- a/src/main/java/org/semux/core/PendingManager.java
+++ b/src/main/java/org/semux/core/PendingManager.java
@@ -20,11 +20,9 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.semux.Kernel;
-import org.semux.config.Config;
 import org.semux.core.state.AccountState;
 import org.semux.core.state.DelegateState;
 import org.semux.net.Channel;
-import org.semux.net.ChannelManager;
 import org.semux.net.msg.p2p.TransactionMessage;
 import org.semux.util.ArrayUtil;
 import org.semux.util.ByteArray;
@@ -63,10 +61,7 @@ public class PendingManager implements Runnable, BlockchainListener {
     private static final int DELAYED_MAX_SIZE = 16 * 1024;
     private static final int PROCESSED_MAX_SIZE = 16 * 1024;
 
-    private Config config;
-
-    private Blockchain chain;
-    private ChannelManager channelMgr;
+    private Kernel kernel;
     private AccountState pendingAS;
     private DelegateState pendingDS;
 
@@ -96,13 +91,10 @@ public class PendingManager implements Runnable, BlockchainListener {
      * Creates a pending manager.
      */
     public PendingManager(Kernel kernel) {
-        this.config = kernel.getConfig();
+        this.kernel = kernel;
 
-        this.chain = kernel.getBlockchain();
-        this.channelMgr = kernel.getChannelManager();
-
-        this.pendingAS = chain.getAccountState().track();
-        this.pendingDS = chain.getDelegateState().track();
+        this.pendingAS = kernel.getBlockchain().getAccountState().track();
+        this.pendingDS = kernel.getBlockchain().getDelegateState().track();
 
         this.exec = Executors.newSingleThreadScheduledExecutor(factory);
     }
@@ -119,7 +111,7 @@ public class PendingManager implements Runnable, BlockchainListener {
              */
             this.validateFuture = exec.scheduleAtFixedRate(this, 2, 2, TimeUnit.MILLISECONDS);
 
-            this.chain.addListener(this);
+            kernel.getBlockchain().addListener(this);
 
             logger.debug("Pending manager started");
             this.isRunning = true;
@@ -247,8 +239,8 @@ public class PendingManager implements Runnable, BlockchainListener {
      */
     public synchronized List<PendingTransaction> reset() {
         // reset state
-        pendingAS = chain.getAccountState().track();
-        pendingDS = chain.getDelegateState().track();
+        pendingAS = kernel.getBlockchain().getAccountState().track();
+        pendingDS = kernel.getBlockchain().getDelegateState().track();
 
         // clear transaction pool
         List<PendingTransaction> txs = new ArrayList<>(transactions);
@@ -283,7 +275,7 @@ public class PendingManager implements Runnable, BlockchainListener {
 
         while (pool.size() < POOL_MAX_SIZE //
                 && (tx = queue.poll()) != null //
-                && tx.getFee() >= config.minTransactionFee()) {
+                && tx.getFee() >= kernel.getConfig().minTransactionFee()) {
 
             // reject already executed transactions
             ByteArray key = ByteArray.of(tx.getHash());
@@ -317,6 +309,11 @@ public class PendingManager implements Runnable, BlockchainListener {
         int cnt = 0;
         long now = System.currentTimeMillis();
 
+        // reject transactions with a duplicated tx hash
+        if (kernel.getBlockchain().hasTransaction(tx.getHash())) {
+            return new ProcessTransactionResult(0, TransactionResult.Error.DUPLICATED_HASH);
+        }
+
         // check transaction timestamp if this is a fresh transaction:
         // a time drift of 2 hours is allowed
         if (tx.getTimestamp() < now - ALLOWED_TIME_DRIFT || tx.getTimestamp() > now + ALLOWED_TIME_DRIFT) {
@@ -331,7 +328,7 @@ public class PendingManager implements Runnable, BlockchainListener {
             // execute transactions
             AccountState as = pendingAS.track();
             DelegateState ds = pendingDS.track();
-            TransactionResult result = new TransactionExecutor(config).execute(tx, as, ds);
+            TransactionResult result = new TransactionExecutor(kernel.getConfig()).execute(tx, as, ds);
 
             if (result.isSuccess()) {
                 // commit state updates
@@ -347,10 +344,10 @@ public class PendingManager implements Runnable, BlockchainListener {
 
                 // relay transaction
                 if (relay) {
-                    List<Channel> channels = channelMgr.getActiveChannels();
+                    List<Channel> channels = kernel.getChannelManager().getActiveChannels();
                     TransactionMessage msg = new TransactionMessage(tx);
                     int[] indices = ArrayUtil.permutation(channels.size());
-                    for (int i = 0; i < indices.length && i < config.netRelayRedundancy(); i++) {
+                    for (int i = 0; i < indices.length && i < kernel.getConfig().netRelayRedundancy(); i++) {
                         Channel c = channels.get(indices[i]);
                         if (c.isActive()) {
                             c.getMessageQueue().sendMessage(msg);

--- a/src/main/java/org/semux/core/TransactionResult.java
+++ b/src/main/java/org/semux/core/TransactionResult.java
@@ -26,6 +26,11 @@ public class TransactionResult {
         INVALID_FORMAT,
 
         /**
+         * The transaction hash is duplicated.
+         */
+        DUPLICATED_HASH,
+
+        /**
          * The transaction timestamp is incorrect. See
          * {@link PendingManager#processTransaction(Transaction, boolean)}.
          */

--- a/src/test/java/org/semux/consensus/SemuxBFTTest.java
+++ b/src/test/java/org/semux/consensus/SemuxBFTTest.java
@@ -78,24 +78,41 @@ public class SemuxBFTTest {
     @Test
     public void testDuplicatedTransaction() {
         // mock blockchain with a single transaction
-        EdDSA from = new EdDSA();
-        Transaction tx = new Transaction(
+        EdDSA to = new EdDSA();
+        EdDSA from1 = new EdDSA();
+        long time = System.currentTimeMillis();
+        Transaction tx1 = new Transaction(
                 TransactionType.TRANSFER, //
-                new EdDSA().toAddress(), //
+                to.toAddress(), //
                 10 * Unit.SEM, //
                 kernelRule.getKernel().getConfig().minTransactionFee(), //
                 0, //
-                System.currentTimeMillis(), //
+                time, //
                 Bytes.EMPTY_BYTES //
-        ).sign(from);
+        ).sign(from1);
         kernelRule.getKernel().setBlockchain(new BlockchainImpl(kernelRule.getKernel().getConfig(), temporaryDBRule));
-        kernelRule.getKernel().getBlockchain().getAccountState().adjustAvailable(from.toAddress(), 1000 * Unit.SEM);
-        Block block1 = kernelRule.createBlock(Arrays.asList(tx));
+        kernelRule.getKernel().getBlockchain().getAccountState().adjustAvailable(from1.toAddress(), 1000 * Unit.SEM);
+        Block block1 = kernelRule.createBlock(Arrays.asList(tx1));
         kernelRule.getKernel().getBlockchain().addBlock(block1);
         SemuxBFT semuxBFT = new SemuxBFT(kernelRule.getKernel());
 
-        // create a duplicated tx in the second block
-        Block block2 = kernelRule.createBlock(Arrays.asList(tx));
+        // create a tx with the same hash with tx1 from a different signer in the second
+        // block
+        EdDSA from2 = new EdDSA();
+        kernelRule.getKernel().getBlockchain().getAccountState().adjustAvailable(from2.toAddress(), 1000 * Unit.SEM);
+        Transaction tx2 = new Transaction(
+                TransactionType.TRANSFER, //
+                to.toAddress(), //
+                10 * Unit.SEM, //
+                kernelRule.getKernel().getConfig().minTransactionFee(), //
+                0, //
+                time, //
+                Bytes.EMPTY_BYTES //
+        ).sign(from2);
+        Block block2 = kernelRule.createBlock(Arrays.asList(tx2));
+
+        // this test case is valid if and only if tx1 and tx2 have the same tx hash
+        assert (Arrays.equals(tx1.getHash(), tx2.getHash()));
 
         // the block should be rejected because of the duplicated tx
         assertFalse(semuxBFT.validateBlock(block2.getHeader(), block2.getTransactions()));

--- a/src/test/java/org/semux/consensus/SemuxSyncTest.java
+++ b/src/test/java/org/semux/consensus/SemuxSyncTest.java
@@ -7,11 +7,16 @@
 package org.semux.consensus;
 
 import static org.junit.Assert.assertFalse;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
 
 import java.util.Arrays;
 
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.semux.core.Block;
 import org.semux.core.BlockchainImpl;
 import org.semux.core.Transaction;
@@ -24,6 +29,7 @@ import org.semux.rules.KernelRule;
 import org.semux.rules.TemporaryDBRule;
 import org.semux.util.Bytes;
 
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class SemuxSyncTest {
 
     @Rule
@@ -35,24 +41,42 @@ public class SemuxSyncTest {
     @Test
     public void testDuplicatedTransaction() {
         // mock blockchain with a single transaction
-        EdDSA from = new EdDSA();
-        Transaction tx = new Transaction(
+        EdDSA to = new EdDSA();
+        EdDSA from1 = new EdDSA();
+        long time = System.currentTimeMillis();
+        Transaction tx1 = new Transaction(
                 TransactionType.TRANSFER, //
-                new EdDSA().toAddress(), //
+                to.toAddress(), //
                 10 * Unit.SEM, //
                 kernelRule.getKernel().getConfig().minTransactionFee(), //
                 0, //
-                System.currentTimeMillis(), //
+                time, //
                 Bytes.EMPTY_BYTES //
-        ).sign(from);
+        ).sign(from1);
         kernelRule.getKernel().setBlockchain(new BlockchainImpl(kernelRule.getKernel().getConfig(), temporaryDBRule));
-        kernelRule.getKernel().getBlockchain().getAccountState().adjustAvailable(from.toAddress(), 1000 * Unit.SEM);
-        Block block1 = kernelRule.createBlock(Arrays.asList(tx));
+        kernelRule.getKernel().getBlockchain().getAccountState().adjustAvailable(from1.toAddress(), 1000 * Unit.SEM);
+        Block block1 = kernelRule.createBlock(Arrays.asList(tx1));
         kernelRule.getKernel().getBlockchain().addBlock(block1);
-        SemuxSync semuxSync = new SemuxSync(kernelRule.getKernel());
+        SemuxSync semuxSync = spy(new SemuxSync(kernelRule.getKernel()));
+        doReturn(true).when(semuxSync).validateBlockVotes(any()); // we don't care about votes here
 
-        // create a duplicated tx in the second block
-        Block block2 = kernelRule.createBlock(Arrays.asList(tx));
+        // create a tx with the same hash with tx1 from a different signer in the second
+        // block
+        EdDSA from2 = new EdDSA();
+        kernelRule.getKernel().getBlockchain().getAccountState().adjustAvailable(from2.toAddress(), 1000 * Unit.SEM);
+        Transaction tx2 = new Transaction(
+                TransactionType.TRANSFER, //
+                to.toAddress(), //
+                10 * Unit.SEM, //
+                kernelRule.getKernel().getConfig().minTransactionFee(), //
+                0, //
+                time, //
+                Bytes.EMPTY_BYTES //
+        ).sign(from2);
+        Block block2 = kernelRule.createBlock(Arrays.asList(tx2));
+
+        // this test case is valid if and only if tx1 and tx2 have the same tx hash
+        assert (Arrays.equals(tx1.getHash(), tx2.getHash()));
 
         // the block should be rejected because of the duplicated tx
         AccountState as = kernelRule.getKernel().getBlockchain().getAccountState().track();

--- a/src/test/java/org/semux/core/BlockchainImplTest.java
+++ b/src/test/java/org/semux/core/BlockchainImplTest.java
@@ -8,6 +8,7 @@ package org.semux.core;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -134,6 +135,16 @@ public class BlockchainImplTest {
         assertTrue(t.getValue() == value);
         assertTrue(t.getNonce() == nonce);
         assertTrue(t.getTimestamp() == timestamp);
+    }
+
+    @Test
+    public void testHasTransaction() {
+        assertFalse(chain.hasTransaction(tx.getHash()));
+
+        Block newBlock = createBlock(1);
+        chain.addBlock(newBlock);
+
+        assertTrue(chain.hasTransaction(tx.getHash()));
     }
 
     @Test


### PR DESCRIPTION
Currently it's possible that an existing transaction gets overwritten in local blockchain database. The issue can be addressed by rejecting all existing transactions by looking up the `indexDb`.

#### References

- https://github.com/bitcoin/bips/blob/master/bip-0030.mediawiki
- https://github.com/bitcoin/bitcoin/commit/a206b0ea12eb4606b93323268fc81a4f1f952531