### PR TITLE
Util: fix cve-2012-2459 (breaking change)

### DIFF
--- a/src/main/java/org/semux/util/MerkleTree.java
+++ b/src/main/java/org/semux/util/MerkleTree.java
@@ -12,7 +12,7 @@ import java.util.List;
 import org.semux.crypto.Hash;
 
 /**
- * Simple implementation of the Merkle tree. TODO: CVE-2012-2459
+ * Simple implementation of the Merkle tree.
  *
  */
 public class MerkleTree {
@@ -90,16 +90,14 @@ public class MerkleTree {
         while (nodes.size() > 1) {
             List<Node> list = new ArrayList<>();
 
-            // duplicate the last element when the number of elements is odd.
-            if (nodes.size() % 2 != 0) {
-                // shallow copy
-                nodes.add(new Node(nodes.get(nodes.size() - 1).value));
-            }
-
-            for (int i = 0; i < nodes.size() - 1; i += 2) {
+            for (int i = 0; i < nodes.size(); i += 2) {
                 Node left = nodes.get(i);
-                Node right = nodes.get(i + 1);
-                list.add(new Node(Hash.h256(left.value, right.value), left, right));
+                if (i + 1 < nodes.size()) {
+                    Node right = nodes.get(i + 1);
+                    list.add(new Node(Hash.h256(left.value, right.value), left, right));
+                } else {
+                    list.add(new Node(left.value, left, null));
+                }
             }
 
             levels++;

--- a/src/test/java/org/semux/util/MerkleTreeTest.java
+++ b/src/test/java/org/semux/util/MerkleTreeTest.java
@@ -62,7 +62,7 @@ public class MerkleTreeTest {
     @Test
     public void testThreeElements() {
         byte[] hash12 = Hash.h256(hash1, hash2);
-        byte[] hash33 = Hash.h256(hash3, hash3);
+        byte[] hash33 = hash3;
         byte[] hash1233 = Hash.h256(hash12, hash33);
 
         MerkleTree tree = new MerkleTree(Arrays.asList(hash1, hash2, hash3));


### PR DESCRIPTION
CVE-2012-2459 has been addressed by BIP 98

#### References

- https://github.com/bitcoin/bips/blob/master/bip-0098.mediawiki#fast-merkle-lists