### PR TITLE
Avoid OOM caused by malicious BFT_NEW_HEIGHT messages

### DIFF
--- a/src/main/java/org/semux/consensus/SemuxBFT.java
+++ b/src/main/java/org/semux/consensus/SemuxBFT.java
@@ -428,11 +428,12 @@ public class SemuxBFT implements Consensus {
     protected void onNewHeight(long newHeight) {
         logger.trace("On new_height: {}", newHeight);
 
+        updateValidators();
         if (newHeight > height && activeValidators != null && !activeValidators.isEmpty()) {
             OptionalLong targetOptional = activeValidators.stream()
                     .mapToLong(c -> c.getRemotePeer().getLatestBlockNumber())
                     .sorted()
-                    .limit((int) Math.floor(activeValidators.size() * 2.0 / 3.0))
+                    .limit(Math.max((int) Math.floor(activeValidators.size() * 2.0 / 3.0), 1))
                     .max();
 
             if (targetOptional.isPresent() && targetOptional.getAsLong() > height) {

--- a/src/main/java/org/semux/core/Blockchain.java
+++ b/src/main/java/org/semux/core/Blockchain.java
@@ -83,6 +83,14 @@ public interface Blockchain {
     BlockHeader getBlockHeader(byte[] hash);
 
     /**
+     * Returns whether the block is existing.
+     *
+     * @param number
+     * @return
+     */
+    boolean hasBlock(long number);
+
+    /**
      * Returns transaction by its hash.
      * 
      * @param hash

--- a/src/main/java/org/semux/core/BlockchainImpl.java
+++ b/src/main/java/org/semux/core/BlockchainImpl.java
@@ -187,7 +187,7 @@ public class BlockchainImpl implements Blockchain {
 
     @Override
     public boolean hasBlock(long number) {
-        return indexDB.get(Bytes.merge(Bytes.of(TYPE_LATEST_BLOCK_NUMBER), Bytes.of(number))) != null;
+        return blockDB.get(Bytes.merge(TYPE_BLOCK_HEADER, Bytes.of(number))) != null;
     }
 
     @Override

--- a/src/main/java/org/semux/core/BlockchainImpl.java
+++ b/src/main/java/org/semux/core/BlockchainImpl.java
@@ -186,6 +186,11 @@ public class BlockchainImpl implements Blockchain {
     }
 
     @Override
+    public boolean hasBlock(long number) {
+        return indexDB.get(Bytes.merge(Bytes.of(TYPE_LATEST_BLOCK_NUMBER), Bytes.of(number))) != null;
+    }
+
+    @Override
     public Transaction getTransaction(byte[] hash) {
         byte[] bytes = indexDB.get(Bytes.merge(TYPE_TRANSACTION_HASH, hash));
         if (bytes != null) {

--- a/src/test/java/org/semux/consensus/SemuxBFTTest.java
+++ b/src/test/java/org/semux/consensus/SemuxBFTTest.java
@@ -12,7 +12,10 @@ import static org.junit.Assert.assertFalse;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
@@ -125,15 +128,18 @@ public class SemuxBFTTest {
     }
 
     @Test
-    public void testOnLargeNewHeight() throws InterruptedException {
+    public void testOnLargeNewHeight() {
         kernelRule.getKernel().start();
 
         // mock consensus
-        SemuxBFT semuxBFT = (SemuxBFT) kernelRule.getKernel().getConsensus();
+        SemuxBFT semuxBFT = spy((SemuxBFT) kernelRule.getKernel().getConsensus());
+        doNothing().when(semuxBFT).updateValidators();
+        doCallRealMethod().when(semuxBFT).onNewHeight(anyLong());
         semuxBFT.activeValidators = Arrays.asList(
                 mockValidator(10L),
                 mockValidator(Long.MAX_VALUE),
                 mockValidator(100L));
+        kernelRule.getKernel().setConsensus(semuxBFT);
 
         // start semuxBFT
         new Thread(() -> semuxBFT.onNewHeight(Long.MAX_VALUE)).start();

--- a/src/test/java/org/semux/core/BlockchainImplTest.java
+++ b/src/test/java/org/semux/core/BlockchainImplTest.java
@@ -97,6 +97,13 @@ public class BlockchainImplTest {
     }
 
     @Test
+    public void testHasBlock() {
+        assertFalse(chain.hasBlock(-1));
+        assertTrue(chain.hasBlock(0));
+        assertFalse(chain.hasBlock(1));
+    }
+
+    @Test
     public void testGetBlockNumber() {
         long number = 1;
         Block newBlock = createBlock(number);

--- a/src/test/java/org/semux/rules/KernelRule.java
+++ b/src/test/java/org/semux/rules/KernelRule.java
@@ -73,6 +73,7 @@ public class KernelRule extends TemporaryFolder {
 
     @Override
     protected void after() {
+        kernel.stop();
         delete();
     }
 


### PR DESCRIPTION
`SemuxSync` may be vulnerable to OOM DoS when `SemuxBFT` receives a `BFT_NEW_HEIGHT` message with a large `height` property.