### PR TITLE
Fix Close Button of Dialogs in GNOME and Other Trivial GUI Issues

### DIFF
--- a/src/main/java/org/semux/gui/SwingUtil.java
+++ b/src/main/java/org/semux/gui/SwingUtil.java
@@ -6,9 +6,9 @@
  */
 package org.semux.gui;
 
-import static org.semux.gui.SwingUtil.TextContextMenuItem.COPY;
-import static org.semux.gui.SwingUtil.TextContextMenuItem.CUT;
-import static org.semux.gui.SwingUtil.TextContextMenuItem.PASTE;
+import static org.semux.gui.TextContextMenuItem.COPY;
+import static org.semux.gui.TextContextMenuItem.CUT;
+import static org.semux.gui.TextContextMenuItem.PASTE;
 
 import java.awt.Color;
 import java.awt.Dimension;
@@ -43,8 +43,6 @@ import javax.swing.JTextArea;
 import javax.swing.JTextField;
 import javax.swing.table.DefaultTableCellRenderer;
 import javax.swing.table.TableColumnModel;
-import javax.swing.text.DefaultEditorKit;
-import javax.swing.text.TextAction;
 
 import org.semux.core.Transaction;
 import org.semux.core.Unit;
@@ -53,7 +51,6 @@ import org.semux.core.state.DelegateState;
 import org.semux.crypto.Hex;
 import org.semux.gui.exception.QRCodeException;
 import org.semux.message.GUIMessages;
-import org.semux.util.exception.UnreachableException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -197,35 +194,6 @@ public class SwingUtil {
             return image;
         } catch (WriterException e) {
             throw new QRCodeException(e);
-        }
-    }
-
-    enum TextContextMenuItem {
-        CUT, COPY, PASTE;
-
-        public TextAction toAction() {
-            switch (this) {
-            case CUT:
-                return new DefaultEditorKit.CutAction();
-            case COPY:
-                return new DefaultEditorKit.CopyAction();
-            case PASTE:
-                return new DefaultEditorKit.PasteAction();
-            }
-            throw new UnreachableException();
-        }
-
-        @Override
-        public String toString() {
-            switch (this) {
-            case CUT:
-                return GUIMessages.get("Cut");
-            case COPY:
-                return GUIMessages.get("Copy");
-            case PASTE:
-                return GUIMessages.get("Paste");
-            }
-            throw new UnreachableException();
         }
     }
 

--- a/src/main/java/org/semux/gui/SwingUtil.java
+++ b/src/main/java/org/semux/gui/SwingUtil.java
@@ -221,6 +221,7 @@ public class SwingUtil {
      */
     public static JTextField textFieldWithCopyPastePopup() {
         JTextField textField = new JTextField();
+        textField.setFont(new Font(Font.MONOSPACED, Font.PLAIN, 13));
         addTextContextMenu(textField, Arrays.asList(COPY, PASTE, CUT));
         return textField;
     }

--- a/src/main/java/org/semux/gui/TextContextMenuItem.java
+++ b/src/main/java/org/semux/gui/TextContextMenuItem.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2017 The Semux Developers
+ *
+ * Distributed under the MIT software license, see the accompanying file
+ * LICENSE or https://opensource.org/licenses/mit-license.php
+ */
+package org.semux.gui;
+
+import javax.swing.text.DefaultEditorKit;
+import javax.swing.text.TextAction;
+
+import org.semux.message.GUIMessages;
+import org.semux.util.exception.UnreachableException;
+
+/**
+ * This enum maintains mappings of text context menu.
+ */
+enum TextContextMenuItem {
+    CUT, COPY, PASTE;
+
+    public TextAction toAction() {
+        switch (this) {
+        case CUT:
+            return new DefaultEditorKit.CutAction();
+        case COPY:
+            return new DefaultEditorKit.CopyAction();
+        case PASTE:
+            return new DefaultEditorKit.PasteAction();
+        }
+        throw new UnreachableException();
+    }
+
+    @Override
+    public String toString() {
+        switch (this) {
+        case CUT:
+            return GUIMessages.get("Cut");
+        case COPY:
+            return GUIMessages.get("Copy");
+        case PASTE:
+            return GUIMessages.get("Paste");
+        }
+        throw new UnreachableException();
+    }
+}

--- a/src/main/java/org/semux/gui/dialog/AddAddressDialog.java
+++ b/src/main/java/org/semux/gui/dialog/AddAddressDialog.java
@@ -6,6 +6,7 @@
  */
 package org.semux.gui.dialog;
 
+import java.awt.Dialog;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 
@@ -32,7 +33,7 @@ public class AddAddressDialog extends JDialog implements ActionListener {
     private JTextField address;
 
     public AddAddressDialog(AddressBookDialog addressBookDialog) {
-        super(addressBookDialog, GUIMessages.get("AddAddress"));
+        super(addressBookDialog, GUIMessages.get("AddAddress"), Dialog.ModalityType.TOOLKIT_MODAL);
         this.addressBookDialog = addressBookDialog;
 
         JLabel lblName = new JLabel("Name");

--- a/src/main/java/org/semux/gui/dialog/AddAddressDialog.java
+++ b/src/main/java/org/semux/gui/dialog/AddAddressDialog.java
@@ -39,8 +39,8 @@ public class AddAddressDialog extends JDialog implements ActionListener {
         JLabel lblName = new JLabel("Name");
         JLabel lblAddress = new JLabel("Address");
 
-        name = new JTextField();
-        address = new JTextField();
+        name = SwingUtil.textFieldWithCopyPastePopup();
+        address = SwingUtil.textFieldWithCopyPastePopup();
 
         JButton btnCancel = SwingUtil.createDefaultButton(GUIMessages.get("Cancel"), this, Action.CANCEL);
         JButton btnOk = SwingUtil.createDefaultButton(GUIMessages.get("OK"), this, Action.OK);

--- a/src/main/java/org/semux/gui/dialog/AddressBookDialog.java
+++ b/src/main/java/org/semux/gui/dialog/AddressBookDialog.java
@@ -8,6 +8,7 @@ package org.semux.gui.dialog;
 
 import java.awt.BorderLayout;
 import java.awt.Color;
+import java.awt.Dialog;
 import java.awt.Dimension;
 import java.awt.Toolkit;
 import java.awt.datatransfer.Clipboard;
@@ -46,6 +47,8 @@ public class AddressBookDialog extends JDialog implements ActionListener {
     private final AddressTableModel tableModel;
 
     public AddressBookDialog(JFrame parent, WalletModel model) {
+        super(null, GUIMessages.get("AddressBook"), Dialog.ModalityType.MODELESS);
+        setName("AddressBookDialog");
         this.model = model;
 
         tableModel = new AddressTableModel();

--- a/src/main/java/org/semux/gui/dialog/DelegateDialog.java
+++ b/src/main/java/org/semux/gui/dialog/DelegateDialog.java
@@ -6,6 +6,8 @@
  */
 package org.semux.gui.dialog;
 
+import java.awt.Dialog;
+
 import javax.swing.GroupLayout;
 import javax.swing.GroupLayout.Alignment;
 import javax.swing.JDialog;
@@ -26,6 +28,8 @@ public class DelegateDialog extends JDialog {
     private static final long serialVersionUID = 1L;
 
     public DelegateDialog(SemuxGUI gui, JFrame parent, WalletDelegate d) {
+        super(null, GUIMessages.get("Delegate"), Dialog.ModalityType.MODELESS);
+        setName("DelegateDialog");
         Block block = gui.getKernel().getBlockchain().getBlock(d.getRegisteredAt());
 
         JLabel lblName = new JLabel(GUIMessages.get("Name") + ":");
@@ -42,6 +46,7 @@ public class DelegateDialog extends JDialog {
         JTextArea address = SwingUtil.textAreaWithCopyPastePopup(Hex.encode0x(d.getAddress()));
         JLabel registeredAt = new JLabel(SwingUtil.formatTimestamp(block.getTimestamp()));
         JLabel votes = new JLabel(SwingUtil.formatVote(d.getVotes()));
+        votes.setName("votes");
         JLabel votesFromMe = new JLabel(SwingUtil.formatVote(d.getVotesFromMe()));
         JLabel numOfBlocksForged = new JLabel(SwingUtil.formatNumber(d.getNumberOfBlocksForged()));
         JLabel numOfTurnsHit = new JLabel(SwingUtil.formatNumber(d.getNumberOfTurnsHit()));

--- a/src/main/java/org/semux/gui/dialog/ExportPrivateKeyDialog.java
+++ b/src/main/java/org/semux/gui/dialog/ExportPrivateKeyDialog.java
@@ -8,6 +8,7 @@ package org.semux.gui.dialog;
 
 import java.awt.BorderLayout;
 import java.awt.Color;
+import java.awt.Dialog;
 import java.awt.Dimension;
 import java.awt.Toolkit;
 import java.awt.datatransfer.Clipboard;
@@ -39,6 +40,7 @@ public class ExportPrivateKeyDialog extends JDialog implements ActionListener {
     private JTable table;
 
     public ExportPrivateKeyDialog(SemuxGUI gui, JFrame parent) {
+        super(null, GUIMessages.get("ExportPrivateKey"), Dialog.ModalityType.MODELESS);
         Wallet wallet = gui.getKernel().getWallet();
 
         Object[][] data = new Object[wallet.size()][];

--- a/src/main/java/org/semux/gui/dialog/TransactionDialog.java
+++ b/src/main/java/org/semux/gui/dialog/TransactionDialog.java
@@ -6,6 +6,8 @@
  */
 package org.semux.gui.dialog;
 
+import java.awt.Dialog;
+
 import javax.swing.GroupLayout;
 import javax.swing.GroupLayout.Alignment;
 import javax.swing.JDialog;
@@ -24,6 +26,8 @@ public class TransactionDialog extends JDialog {
     private static final long serialVersionUID = 1L;
 
     public TransactionDialog(JFrame parent, Transaction tx) {
+        super(null, GUIMessages.get("Transaction"), Dialog.ModalityType.MODELESS);
+        setName("TransactionDialog");
 
         JLabel lblHash = new JLabel(GUIMessages.get("Hash") + ":");
         JLabel lblType = new JLabel(GUIMessages.get("Type") + ":");
@@ -36,14 +40,23 @@ public class TransactionDialog extends JDialog {
         JLabel lblData = new JLabel(GUIMessages.get("Data") + ":");
 
         JTextArea hash = SwingUtil.textAreaWithCopyPastePopup(Hex.encode0x(tx.getHash()));
+        hash.setName("hashText");
         JLabel type = new JLabel(tx.getType().name());
+        type.setName("typeText");
         JTextArea from = SwingUtil.textAreaWithCopyPastePopup(Hex.encode0x(tx.getFrom()));
+        from.setName("fromText");
         JTextArea to = SwingUtil.textAreaWithCopyPastePopup(Hex.encode0x(tx.getTo()));
+        to.setName("toText");
         JLabel value = new JLabel(SwingUtil.formatValue((tx.getValue())));
+        value.setName("valueText");
         JLabel fee = new JLabel(SwingUtil.formatValue((tx.getFee())));
+        fee.setName("feeText");
         JLabel nonce = new JLabel(SwingUtil.formatNumber(tx.getNonce()));
+        nonce.setName("nonceText");
         JLabel timestamp = new JLabel(SwingUtil.formatTimestamp(tx.getTimestamp()));
+        timestamp.setName("timestampText");
         JTextArea data = new JTextArea(Hex.encode0x(tx.getData()));
+        data.setName("dataText");
         data.setEditable(false);
 
         // @formatter:off

--- a/src/test/java/org/semux/gui/dialog/AddressBookDialogTest.java
+++ b/src/test/java/org/semux/gui/dialog/AddressBookDialogTest.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) 2017 The Semux Developers
+ *
+ * Distributed under the MIT software license, see the accompanying file
+ * LICENSE or https://opensource.org/licenses/mit-license.php
+ */
+package org.semux.gui.dialog;
+
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+
+import org.assertj.swing.edt.GuiActionRunner;
+import org.assertj.swing.fixture.FrameFixture;
+import org.assertj.swing.junit.testcase.AssertJSwingJUnitTestCase;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.semux.crypto.EdDSA;
+import org.semux.gui.AddressBook;
+import org.semux.gui.model.WalletModel;
+import org.semux.rules.KernelRule;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AddressBookDialogTest extends AssertJSwingJUnitTestCase {
+
+    @Rule
+    public KernelRule kernelRule1 = new KernelRule(51610, 51710);
+
+    @Mock
+    WalletModel walletModel;
+
+    @Mock
+    AddressBook addressBook;
+
+    @Test
+    public void testListAddressBook() {
+        EdDSA account1 = new EdDSA(), account2 = new EdDSA();
+        when(addressBook.list()).thenReturn(Arrays.asList(
+                new AddressBook.Entry("address1", account1.toAddressString()),
+                new AddressBook.Entry("address2", account2.toAddressString())));
+        when(walletModel.getAddressBook()).thenReturn(addressBook);
+
+        AddressBookDialogTestApplication application = GuiActionRunner
+                .execute(() -> new AddressBookDialogTestApplication(walletModel, kernelRule1.getKernel()));
+
+        FrameFixture window = new FrameFixture(robot(), application);
+        window.show().requireVisible().moveToFront();
+        window.dialog("AddressBookDialog").requireVisible()
+                .table().requireVisible().requireRowCount(2).requireContents(new String[][] {
+                        { "address1", account1.toAddressString() },
+                        { "address2", account2.toAddressString() }
+                });
+    }
+
+    @Override
+    protected void onSetUp() {
+
+    }
+}

--- a/src/test/java/org/semux/gui/dialog/AddressBookDialogTestApplication.java
+++ b/src/test/java/org/semux/gui/dialog/AddressBookDialogTestApplication.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2017 The Semux Developers
+ *
+ * Distributed under the MIT software license, see the accompanying file
+ * LICENSE or https://opensource.org/licenses/mit-license.php
+ */
+package org.semux.gui.dialog;
+
+import org.semux.KernelMock;
+import org.semux.gui.BaseTestApplication;
+import org.semux.gui.SemuxGUI;
+import org.semux.gui.model.WalletModel;
+
+public class AddressBookDialogTestApplication extends BaseTestApplication {
+
+    private static final long serialVersionUID = 1L;
+
+    SemuxGUI gui;
+
+    AddressBookDialog addressBookDialog;
+
+    AddressBookDialogTestApplication(WalletModel walletModel, KernelMock kernelMock) {
+        super();
+        gui = new SemuxGUI(walletModel, kernelMock);
+        addressBookDialog = new AddressBookDialog(this, walletModel);
+        addressBookDialog.setVisible(true);
+    }
+}

--- a/src/test/java/org/semux/gui/dialog/DelegateDialogTest.java
+++ b/src/test/java/org/semux/gui/dialog/DelegateDialogTest.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2017 The Semux Developers
+ *
+ * Distributed under the MIT software license, see the accompanying file
+ * LICENSE or https://opensource.org/licenses/mit-license.php
+ */
+package org.semux.gui.dialog;
+
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+
+import org.assertj.swing.edt.GuiActionRunner;
+import org.assertj.swing.fixture.FrameFixture;
+import org.assertj.swing.junit.testcase.AssertJSwingJUnitTestCase;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.semux.core.Unit;
+import org.semux.core.state.Delegate;
+import org.semux.crypto.EdDSA;
+import org.semux.gui.model.WalletDelegate;
+import org.semux.gui.model.WalletModel;
+import org.semux.rules.KernelRule;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DelegateDialogTest extends AssertJSwingJUnitTestCase {
+
+    @Rule
+    public KernelRule kernelRule1 = new KernelRule(51610, 51710);
+
+    @Mock
+    WalletModel walletModel;
+
+    @Test
+    public void testDisplayVotes() {
+        Delegate delegate = new Delegate(new EdDSA().toAddress(), new String("delegate1").getBytes(), 0L,
+                123L * Unit.SEM);
+        WalletDelegate walletDelegate = new WalletDelegate(delegate);
+        when(walletModel.getDelegates()).thenReturn(Arrays.asList(walletDelegate));
+
+        kernelRule1.getKernel().start();
+
+        DelegateDialogTestApplication application = GuiActionRunner
+                .execute(() -> new DelegateDialogTestApplication(walletModel, kernelRule1.getKernel()));
+
+        FrameFixture window = new FrameFixture(robot(), application);
+        window.show().requireVisible().moveToFront()
+                .dialog("DelegateDialog").requireVisible()
+                .label("votes").requireText("123");
+    }
+
+    @Override
+    protected void onSetUp() {
+
+    }
+}

--- a/src/test/java/org/semux/gui/dialog/DelegateDialogTestApplication.java
+++ b/src/test/java/org/semux/gui/dialog/DelegateDialogTestApplication.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2017 The Semux Developers
+ *
+ * Distributed under the MIT software license, see the accompanying file
+ * LICENSE or https://opensource.org/licenses/mit-license.php
+ */
+package org.semux.gui.dialog;
+
+import org.semux.KernelMock;
+import org.semux.gui.BaseTestApplication;
+import org.semux.gui.SemuxGUI;
+import org.semux.gui.model.WalletModel;
+
+public class DelegateDialogTestApplication extends BaseTestApplication {
+
+    private static final long serialVersionUID = 1L;
+
+    SemuxGUI gui;
+
+    DelegateDialog delegateDialog;
+
+    DelegateDialogTestApplication(WalletModel walletModel, KernelMock kernelMock) {
+        super();
+        gui = new SemuxGUI(walletModel, kernelMock);
+        delegateDialog = new DelegateDialog(gui, this, walletModel.getDelegates().get(0));
+        delegateDialog.setVisible(true);
+    }
+}

--- a/src/test/java/org/semux/gui/dialog/TransactionDialogTest.java
+++ b/src/test/java/org/semux/gui/dialog/TransactionDialogTest.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) 2017 The Semux Developers
+ *
+ * Distributed under the MIT software license, see the accompanying file
+ * LICENSE or https://opensource.org/licenses/mit-license.php
+ */
+package org.semux.gui.dialog;
+
+import java.time.Instant;
+
+import org.assertj.swing.edt.GuiActionRunner;
+import org.assertj.swing.finder.DialogFinder;
+import org.assertj.swing.fixture.DialogFixture;
+import org.assertj.swing.fixture.FrameFixture;
+import org.assertj.swing.junit.testcase.AssertJSwingJUnitTestCase;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.semux.core.Transaction;
+import org.semux.core.TransactionType;
+import org.semux.core.Unit;
+import org.semux.crypto.EdDSA;
+import org.semux.crypto.Hex;
+import org.semux.gui.SwingUtil;
+import org.semux.gui.model.WalletModel;
+import org.semux.rules.KernelRule;
+
+@RunWith(MockitoJUnitRunner.class)
+public class TransactionDialogTest extends AssertJSwingJUnitTestCase {
+
+    @Rule
+    public KernelRule kernelRule1 = new KernelRule(51610, 51710);
+
+    @Mock
+    WalletModel walletModel;
+
+    @Test
+    public void testDisplayTransferTransaction() {
+        kernelRule1.getKernel().start();
+
+        final EdDSA from = new EdDSA();
+        final EdDSA to = new EdDSA();
+        final long value = 1000 * Unit.SEM;
+        final long fee = (long) (0.05 * Unit.SEM);
+        final long now = Instant.now().toEpochMilli();
+        final byte[] data = new String("some data").getBytes();
+        Transaction tx = new Transaction(
+                TransactionType.TRANSFER,
+                to.toAddress(),
+                value,
+                fee,
+                0,
+                now,
+                data).sign(from);
+
+        TransactionDialogTestApplication application = GuiActionRunner
+                .execute(() -> new TransactionDialogTestApplication(walletModel, tx, kernelRule1.getKernel()));
+
+        FrameFixture window = new FrameFixture(robot(), application);
+        DialogFixture dialog = window.show().requireVisible().moveToFront()
+                .dialog("TransactionDialog").requireVisible();
+
+        dialog.textBox("hashText").requireVisible().requireText(Hex.encode0x(tx.getHash()));
+        dialog.textBox("fromText").requireVisible().requireText(Hex.encode0x(from.toAddress()));
+        dialog.textBox("toText").requireVisible().requireText(Hex.encode0x(to.toAddress()));
+        dialog.label("valueText").requireVisible().requireText(SwingUtil.formatValue(value));
+        dialog.label("feeText").requireVisible().requireText(SwingUtil.formatValue(fee));
+        dialog.label("nonceText").requireVisible().requireText("0");
+        dialog.label("timestampText").requireVisible().requireText(SwingUtil.formatTimestamp(now));
+        dialog.textBox("dataText").requireVisible().requireText(Hex.encode0x(data));
+    }
+
+    @Override
+    protected void onSetUp() {
+
+    }
+}

--- a/src/test/java/org/semux/gui/dialog/TransactionDialogTest.java
+++ b/src/test/java/org/semux/gui/dialog/TransactionDialogTest.java
@@ -6,10 +6,11 @@
  */
 package org.semux.gui.dialog;
 
+import static org.semux.core.TransactionType.TRANSFER;
+
 import java.time.Instant;
 
 import org.assertj.swing.edt.GuiActionRunner;
-import org.assertj.swing.finder.DialogFinder;
 import org.assertj.swing.fixture.DialogFixture;
 import org.assertj.swing.fixture.FrameFixture;
 import org.assertj.swing.junit.testcase.AssertJSwingJUnitTestCase;
@@ -40,20 +41,16 @@ public class TransactionDialogTest extends AssertJSwingJUnitTestCase {
     public void testDisplayTransferTransaction() {
         kernelRule1.getKernel().start();
 
-        final EdDSA from = new EdDSA();
-        final EdDSA to = new EdDSA();
-        final long value = 1000 * Unit.SEM;
-        final long fee = (long) (0.05 * Unit.SEM);
-        final long now = Instant.now().toEpochMilli();
-        final byte[] data = new String("some data").getBytes();
-        Transaction tx = new Transaction(
-                TransactionType.TRANSFER,
-                to.toAddress(),
-                value,
-                fee,
-                0,
-                now,
-                data).sign(from);
+        TransactionType type = TRANSFER;
+        EdDSA from = new EdDSA();
+        EdDSA to = new EdDSA();
+        long value = 1000 * Unit.SEM;
+        long fee = (long) (0.05 * Unit.SEM);
+        long nonce = 0L;
+        long now = Instant.now().toEpochMilli();
+        byte[] data = "some data".getBytes();
+        Transaction tx = new Transaction(kernelRule1.getKernel().getConfig().networkId(), type, to.toAddress(), value,
+                fee, nonce, now, data).sign(from);
 
         TransactionDialogTestApplication application = GuiActionRunner
                 .execute(() -> new TransactionDialogTestApplication(walletModel, tx, kernelRule1.getKernel()));

--- a/src/test/java/org/semux/gui/dialog/TransactionDialogTestApplication.java
+++ b/src/test/java/org/semux/gui/dialog/TransactionDialogTestApplication.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2017 The Semux Developers
+ *
+ * Distributed under the MIT software license, see the accompanying file
+ * LICENSE or https://opensource.org/licenses/mit-license.php
+ */
+package org.semux.gui.dialog;
+
+import org.semux.KernelMock;
+import org.semux.core.Transaction;
+import org.semux.gui.BaseTestApplication;
+import org.semux.gui.SemuxGUI;
+import org.semux.gui.model.WalletModel;
+
+public class TransactionDialogTestApplication extends BaseTestApplication {
+
+    private static final long serialVersionUID = 1L;
+
+    SemuxGUI gui;
+
+    TransactionDialog transactionDialog;
+
+    TransactionDialogTestApplication(WalletModel walletModel, Transaction tx, KernelMock kernelMock) {
+        super();
+        gui = new SemuxGUI(walletModel, kernelMock);
+        transactionDialog = new TransactionDialog(this, tx);
+        transactionDialog.setVisible(true);
+    }
+}


### PR DESCRIPTION
Close button of dialogs is not currently displayed in GNOME desktop.

![selection_073](https://user-images.githubusercontent.com/32390172/34518809-21582e30-f0bc-11e7-99f6-7451f93d0b8a.png)
