### PR TITLE
GUI: OSX puts DB/wallet in ~/Library/Application Support fixes #260

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -140,15 +140,16 @@
                 <artifactId>appbundle-maven-plugin</artifactId>
                 <version>1.2.0</version>
                 <configuration>
-                    <mainClass>org.semux.gui.SemuxGUI</mainClass>
+                    <mainClass>org.semux.gui.ApplicationLauncher</mainClass>
                     <!-- scrutinizer doesn't like to build OSX DMGs uncomment for build. -->
                     <!--<generateDiskImageFile>true</generateDiskImageFile>-->
                     <jvmVersion>1.8</jvmVersion>
                     <iconFile>logo.icns</iconFile>
+                    <!-- put database and wallet in app support -->
+                    <dictionaryFile>Info.plist.template</dictionaryFile>
                     <additionalResources>
                         <additionalResource>
                             <includes>
-                                <include>config/**</include>
                                 <include>LICENSE*</include>
                             </includes>
                             <directory>${project.basedir}</directory>
@@ -210,7 +211,6 @@
                                       tofile="${dist.base}/linux/config/logback.xml"/> />
 
                                 <!-- osx build (dmg) -->
-                                <!-- will work with above 'generateDiskImageFile' uncommented - for now just get clean build -->
                                 <copy todir="${dist.base}/macos">
                                     <fileset dir="${project.basedir}/target/semux-${project.version}">
                                     </fileset>

--- a/src/main/java/org/semux/Launcher.java
+++ b/src/main/java/org/semux/Launcher.java
@@ -27,6 +27,7 @@ public abstract class Launcher {
     protected static final String DEVNET = "devnet";
     protected static final String TESTNET = "testnet";
     protected static final String MAINNET = "mainnet";
+    public static final String USER_HOME = "user.home";
 
     private Options options = new Options();
 
@@ -112,6 +113,19 @@ public abstract class Launcher {
         LoggerConfigurator.configure(
                 new File(cmd.hasOption(SemuxOption.DATA_DIR.name()) ? cmd.getOptionValue(SemuxOption.DATA_DIR.name())
                         : Constants.DEFAULT_DATA_DIR));
+    }
+    /**
+     * support shell expansions of ~
+     * @param directoryPath
+     * @return
+     */
+    protected String replaceShellExpansions(String directoryPath)
+    {
+        if (directoryPath.startsWith("~" + File.separator))
+        {
+            directoryPath = System.getProperty(USER_HOME) + directoryPath.substring(1);
+        }
+        return directoryPath;
     }
 
     /**

--- a/src/main/java/org/semux/cli/SemuxCLI.java
+++ b/src/main/java/org/semux/cli/SemuxCLI.java
@@ -118,7 +118,7 @@ public class SemuxCLI extends Launcher {
         CommandLine cmd = parseOptions(args);
 
         if (cmd.hasOption(SemuxOption.DATA_DIR.toString())) {
-            setDataDir(cmd.getOptionValue(SemuxOption.DATA_DIR.toString()));
+            setDataDir(replaceShellExpansions(cmd.getOptionValue(SemuxOption.DATA_DIR.toString())));
         }
 
         if (cmd.hasOption(SemuxOption.COINBASE.toString())) {

--- a/src/main/java/org/semux/config/AbstractConfig.java
+++ b/src/main/java/org/semux/config/AbstractConfig.java
@@ -31,7 +31,7 @@ public abstract class AbstractConfig implements Config {
 
     private static final Logger logger = LoggerFactory.getLogger(AbstractConfig.class);
 
-    private static final String CONFIG_FILE = "semux.properties";
+    public static final String CONFIG_FILE = "semux.properties";
 
     // =========================
     // General

--- a/src/main/java/org/semux/gui/ApplicationLauncher.java
+++ b/src/main/java/org/semux/gui/ApplicationLauncher.java
@@ -1,0 +1,108 @@
+package org.semux.gui;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.ParseException;
+import org.semux.Launcher;
+import org.semux.cli.SemuxOption;
+import org.semux.config.AbstractConfig;
+import org.semux.message.CLIMessages;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+
+/**
+ * Check if configuration files exist, if not copy them from defaults
+ * Then load SemuxGUI.
+ */
+public class ApplicationLauncher extends Launcher
+{
+    private static final Logger logger = LoggerFactory.getLogger(ApplicationLauncher.class);
+    public static final String DEFAULT_PROPERTIES = "default.properties";
+
+    public static void main(String[] args) throws ParseException, IOException, InterruptedException
+    {
+        ApplicationLauncher launcher = new ApplicationLauncher();
+        launcher.checkConfiguration(args);
+
+        //launch app
+        SemuxGUI.main(args);
+    }
+
+    public ApplicationLauncher()
+    {
+        Option dataDirOption = Option.builder()
+            .longOpt(SemuxOption.DATA_DIR.toString())
+            .desc(CLIMessages.get("SpecifyDataDir"))
+            .hasArg(true).numberOfArgs(1).optionalArg(false).argName("path").type(String.class)
+            .build();
+        addOption(dataDirOption);
+    }
+
+    /**
+     * Check that the expected directory structure and configuration file exists
+     * If not, create them.
+     *
+     * @param args args
+     * @throws ParseException
+     * @throws IOException
+     */
+    private void checkConfiguration(String[] args) throws ParseException, IOException
+    {
+        CommandLineParser parser = new DefaultParser();
+        CommandLine cmd = parser.parse(getOptions(), args);
+
+        String configurationDirPath = getDataDirPath(cmd) + File.separator + "config";
+
+        //check if config directory exists, if not, create directories.
+        File configurationDir = new File(configurationDirPath);
+        if (!configurationDir.exists() && !configurationDir.mkdirs())
+        {
+            throw new ParseException("Unable to create config directory.");
+        }
+
+        //check if config directory exists, and create if necessary
+        createConfigFileIfNotExists(configurationDir);
+    }
+
+    private void createConfigFileIfNotExists(File configurationDir) throws ParseException
+    {
+        // get the configuration properties
+        File configuration = new File(configurationDir.getAbsolutePath() + File.separator + AbstractConfig.CONFIG_FILE);
+        if (!configuration.exists())
+        {
+            ClassLoader classLoader = getClass().getClassLoader();
+            InputStream defaultProperty = classLoader.getResourceAsStream(DEFAULT_PROPERTIES);
+
+            //copy the default configuration
+            try
+            {
+                Files.copy(defaultProperty, configuration.toPath());
+            }
+            catch (IOException e)
+            {
+                logger.error("Unable to copy default properties.", e);
+            }
+        }
+    }
+
+    private String getDataDirPath(CommandLine cmd)
+    {
+        String dataDirPath = ".";
+
+        //check if datadir is overridden
+        if (cmd.hasOption(SemuxOption.DATA_DIR.toString()))
+        {
+            dataDirPath = cmd.getOptionValue(SemuxOption.DATA_DIR.toString());
+        }
+
+        dataDirPath = replaceShellExpansions(dataDirPath);
+        return dataDirPath;
+    }
+}

--- a/src/main/java/org/semux/gui/SemuxGUI.java
+++ b/src/main/java/org/semux/gui/SemuxGUI.java
@@ -6,22 +6,8 @@
  */
 package org.semux.gui;
 
-import java.awt.EventQueue;
-import java.io.File;
-import java.io.IOException;
-import java.net.URL;
-import java.net.URLConnection;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import javax.swing.JFrame;
-import javax.swing.JOptionPane;
-import javax.swing.UIManager;
-import javax.swing.UnsupportedLookAndFeelException;
-
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.DefaultParser;
@@ -53,8 +39,17 @@ import org.semux.util.SystemUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import javax.swing.*;
+import java.awt.*;
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLConnection;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Graphic user interface.
@@ -143,8 +138,9 @@ public class SemuxGUI extends Launcher {
         CommandLineParser parser = new DefaultParser();
         CommandLine cmd = parser.parse(getOptions(), args);
 
-        if (cmd.hasOption(SemuxOption.DATA_DIR.toString())) {
-            setDataDir(cmd.getOptionValue(SemuxOption.DATA_DIR.toString()));
+        if (cmd.hasOption(SemuxOption.DATA_DIR.toString()))
+        {
+            setDataDir(replaceShellExpansions(cmd.getOptionValue(SemuxOption.DATA_DIR.toString())));
         }
 
         if (cmd.hasOption(SemuxOption.NETWORK.toString())) {

--- a/src/main/java/org/semux/gui/SemuxGUI.java
+++ b/src/main/java/org/semux/gui/SemuxGUI.java
@@ -6,8 +6,22 @@
  */
 package org.semux.gui;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import java.awt.EventQueue;
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLConnection;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.swing.JFrame;
+import javax.swing.JOptionPane;
+import javax.swing.UIManager;
+import javax.swing.UnsupportedLookAndFeelException;
+
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.DefaultParser;
@@ -39,17 +53,8 @@ import org.semux.util.SystemUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.swing.*;
-import java.awt.*;
-import java.io.File;
-import java.io.IOException;
-import java.net.URL;
-import java.net.URLConnection;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * Graphic user interface.

--- a/src/main/resources/Info.plist.template
+++ b/src/main/resources/Info.plist.template
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>English</string>
+    <key>CFBundleExecutable</key>
+    <string>${cfBundleExecutable}</string>
+    <key>CFBundleIconFile</key>
+    <string>${iconFile}</string>
+    <key>CFBundleIdentifier</key>
+    <string>${mainClass}</string>
+    <key>CFBundleDisplayName</key>
+    <string>${bundleName}</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>${bundleName}</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleShortVersionString</key>
+    <string>${version}</string>
+    <key>CFBundleSignature</key>
+    <string>????</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>NSHumanReadableCopyright</key>
+    <string></string>
+    <key>NSHighResolutionCapable</key>
+    <true/>
+    <key>NSSupportsAutomaticGraphicsSwitching</key>
+    <true/>
+    <key>JVMRuntime</key>
+    <string>${jrePath}</string>
+    <key>JVMRuntimePath</key>
+    <string>${jreFullPath}</string>
+    <key>JVMMainClassName</key>
+    <string>${mainClass}</string>
+    <key>JVMClassPaths</key>
+    ${classpath}
+    <key>JVMVersion</key>
+    <string>${jvmVersion}</string>
+    <key>JVMOptions</key>
+    ${jvmOptions}
+    <key>JVMArguments</key>
+    <array>
+      <string>--datadir=~/Library/Application Support/Semux</string>
+    </array>
+    <key>LauncherWorkingDirectory</key>
+    <string>$APP_ROOT/../</string>
+  </dict>
+</plist>

--- a/src/main/resources/default.properties
+++ b/src/main/resources/default.properties
@@ -1,0 +1,65 @@
+################################################################################
+#                                                                              #
+# Copyright (c) 2017 The Semux Developers                                      #
+#                                                                              #
+# Distributed under the MIT software license, see the accompanying file        #
+# LICENSE or https://opensource.org/licenses/mit-license.php                   #
+#                                                                              #
+################################################################################
+
+#================
+# General
+#================
+
+# Log directory
+log.dir=.
+
+
+#================
+# P2P
+#================
+
+# Declared ip address
+p2p.declaredIp =
+
+# Binding IP address and port
+p2p.listenIp = 0.0.0.0
+p2p.listenPort = 5161
+
+# Seed nodes, IP addresses separated by comma
+p2p.seedNodes =
+
+
+#================
+# Network
+#================
+
+# Max number of inbound connections
+net.maxInboundConnections = 1024
+
+# Max number of outbound connections
+net.maxOutboundConnections = 128
+
+# Max message queue size
+net.maxMessageQueueSize = 4096
+
+# Message relay redundancy
+net.relayRedundancy = 16
+
+# Channel idle timeout, ms
+net.channelIdleTimeout = 120000
+
+#================
+# API
+#================
+
+# Be sure to set up authentication first before enabling API
+api.enabled = false
+
+# Listening address and port
+api.listenIp = 127.0.0.1
+api.listenPort = 5171
+
+# Basic authentication
+api.username = YOUR_API_USERNAME
+api.password = YOUR_API_PASSWORD

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -5,9 +5,11 @@
             <pattern>%date{HH:mm:ss.SSS} %-8([%level]) %-16logger{0} %msg%n</pattern>
         </encoder>
     </appender>
+    <property resource="default.properties" />
+    <property file="config/semux.properties" />
 
     <appender name="FILE" class="ch.qos.logback.core.FileAppender">
-        <file>debug.log</file>
+        <file>${log.dir}/debug.log</file>
         <append>true</append>
         <immediateFlush>true</immediateFlush>
         <encoder>


### PR DESCRIPTION
Previously, the wallet and db were placed in the app itself.
Put it in the OSX expected location.  Log files are also
moved out of the app itself.  A template config is packaged
with the app and created if it does not exist.

OSX users like to have the .app as one atomic unit, so
external configuration should not be required or created
for them.

fixes #260