### PR TITLE
API: add /get_transaction_limits?type

### DIFF
--- a/src/main/java/org/semux/api/ApiHandlerImpl.java
+++ b/src/main/java/org/semux/api/ApiHandlerImpl.java
@@ -7,6 +7,7 @@
 package org.semux.api;
 
 import java.net.UnknownHostException;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -27,6 +28,7 @@ import org.semux.api.response.GetLatestBlockResponse;
 import org.semux.api.response.GetPeersResponse;
 import org.semux.api.response.GetPendingTransactionsResponse;
 import org.semux.api.response.GetRootResponse;
+import org.semux.api.response.GetTransactionLimitsResponse;
 import org.semux.api.response.GetTransactionResponse;
 import org.semux.api.response.GetValidatorsResponse;
 import org.semux.api.response.GetVoteResponse;
@@ -140,6 +142,9 @@ public class ApiHandlerImpl implements ApiHandler {
 
             case CREATE_ACCOUNT:
                 return createAccount();
+
+            case GET_TRANSACTION_LIMITS:
+                return getTransactionLimits(params);
 
             case TRANSFER:
             case DELEGATE:
@@ -557,6 +562,24 @@ public class ApiHandlerImpl implements ApiHandler {
             return new CreateAccountResponse(true, Hex.PREF + key.toAddressString());
         } catch (WalletLockedException e) {
             return failure(e.getMessage());
+        }
+    }
+
+    /**
+     * GET /get_transaction_limits
+     *
+     * @param params
+     * @return
+     */
+    private ApiHandlerResponse getTransactionLimits(Map<String, String> params) {
+        try {
+            return new GetTransactionLimitsResponse(kernel, TransactionType.valueOf(params.get("type")));
+        } catch (NullPointerException | IllegalArgumentException e) {
+            return failure(String.format(
+                    "Invalid transaction type. (must be one of %s)",
+                    Arrays.stream(TransactionType.values())
+                            .map(TransactionType::toString)
+                            .collect(Collectors.joining(","))));
         }
     }
 

--- a/src/main/java/org/semux/api/Command.java
+++ b/src/main/java/org/semux/api/Command.java
@@ -130,6 +130,11 @@ public enum Command {
     CREATE_ACCOUNT,
 
     /**
+     * Get transaction limits.
+     */
+    GET_TRANSACTION_LIMITS,
+
+    /**
      * Balance transfer.
      */
     TRANSFER,

--- a/src/main/java/org/semux/api/response/GetTransactionLimitsResponse.java
+++ b/src/main/java/org/semux/api/response/GetTransactionLimitsResponse.java
@@ -6,11 +6,14 @@
  */
 package org.semux.api.response;
 
+import static org.semux.core.TransactionType.DELEGATE;
+
 import org.semux.Kernel;
 import org.semux.api.ApiHandlerResponse;
 import org.semux.core.TransactionType;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class GetTransactionLimitsResponse extends ApiHandlerResponse {
@@ -22,7 +25,8 @@ public class GetTransactionLimitsResponse extends ApiHandlerResponse {
         super(true, null);
         this.result = new Result(
                 kernel.getConfig().maxTransactionDataSize(transactionType),
-                kernel.getConfig().minTransactionFee());
+                kernel.getConfig().minTransactionFee(),
+                transactionType.equals(DELEGATE) ? kernel.getConfig().minDelegateBurnAmount() : null);
     }
 
     @JsonCreator
@@ -36,17 +40,23 @@ public class GetTransactionLimitsResponse extends ApiHandlerResponse {
     public static class Result {
 
         @JsonProperty("maxTransactionDataSize")
-        public final int maxTransactionDataSize;
+        public final Integer maxTransactionDataSize;
 
         @JsonProperty("minTransactionFee")
-        public final long minTransactionFee;
+        public final Long minTransactionFee;
+
+        @JsonProperty("minDelegateBurnAmount")
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        public final Long minDelegateBurnAmount;
 
         @JsonCreator
         public Result(
-                @JsonProperty("maxTransactionDataSize") int maxTransactionDataSize,
-                @JsonProperty("minTransactionFee") long minTransactionFee) {
+                @JsonProperty("maxTransactionDataSize") Integer maxTransactionDataSize,
+                @JsonProperty("minTransactionFee") Long minTransactionFee,
+                @JsonProperty("minDelegateBurnAmount") Long minDelegateBurnAmount) {
             this.maxTransactionDataSize = maxTransactionDataSize;
             this.minTransactionFee = minTransactionFee;
+            this.minDelegateBurnAmount = minDelegateBurnAmount;
         }
     }
 }

--- a/src/main/java/org/semux/api/response/GetTransactionLimitsResponse.java
+++ b/src/main/java/org/semux/api/response/GetTransactionLimitsResponse.java
@@ -22,8 +22,7 @@ public class GetTransactionLimitsResponse extends ApiHandlerResponse {
         super(true, null);
         this.result = new Result(
                 kernel.getConfig().maxTransactionDataSize(transactionType),
-                kernel.getConfig().minTransactionFee(),
-                kernel.getConfig().minDelegateBurnAmount());
+                kernel.getConfig().minTransactionFee());
     }
 
     @JsonCreator
@@ -42,17 +41,12 @@ public class GetTransactionLimitsResponse extends ApiHandlerResponse {
         @JsonProperty("minTransactionFee")
         public final long minTransactionFee;
 
-        @JsonProperty("minDelegateBurnAmount")
-        public final long minDelegateBurnAmount;
-
         @JsonCreator
         public Result(
                 @JsonProperty("maxTransactionDataSize") int maxTransactionDataSize,
-                @JsonProperty("minTransactionFee") long minTransactionFee,
-                @JsonProperty("minDelegateBurnAmount") long minDelegateBurnAmount) {
+                @JsonProperty("minTransactionFee") long minTransactionFee) {
             this.maxTransactionDataSize = maxTransactionDataSize;
             this.minTransactionFee = minTransactionFee;
-            this.minDelegateBurnAmount = minDelegateBurnAmount;
         }
     }
 }

--- a/src/main/java/org/semux/api/response/GetTransactionLimitsResponse.java
+++ b/src/main/java/org/semux/api/response/GetTransactionLimitsResponse.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) 2017 The Semux Developers
+ *
+ * Distributed under the MIT software license, see the accompanying file
+ * LICENSE or https://opensource.org/licenses/mit-license.php
+ */
+package org.semux.api.response;
+
+import org.semux.Kernel;
+import org.semux.api.ApiHandlerResponse;
+import org.semux.core.TransactionType;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class GetTransactionLimitsResponse extends ApiHandlerResponse {
+
+    @JsonProperty("result")
+    public final Result result;
+
+    public GetTransactionLimitsResponse(Kernel kernel, TransactionType transactionType) {
+        super(true, null);
+        this.result = new Result(
+                kernel.getConfig().maxTransactionDataSize(transactionType),
+                kernel.getConfig().minTransactionFee(),
+                kernel.getConfig().minDelegateBurnAmount());
+    }
+
+    @JsonCreator
+    public GetTransactionLimitsResponse(
+            @JsonProperty("success") Boolean success,
+            @JsonProperty("result") Result result) {
+        super(success, null);
+        this.result = result;
+    }
+
+    public static class Result {
+
+        @JsonProperty("maxTransactionDataSize")
+        public final int maxTransactionDataSize;
+
+        @JsonProperty("minTransactionFee")
+        public final long minTransactionFee;
+
+        @JsonProperty("minDelegateBurnAmount")
+        public final long minDelegateBurnAmount;
+
+        @JsonCreator
+        public Result(
+                @JsonProperty("maxTransactionDataSize") int maxTransactionDataSize,
+                @JsonProperty("minTransactionFee") long minTransactionFee,
+                @JsonProperty("minDelegateBurnAmount") long minDelegateBurnAmount) {
+            this.maxTransactionDataSize = maxTransactionDataSize;
+            this.minTransactionFee = minTransactionFee;
+            this.minDelegateBurnAmount = minDelegateBurnAmount;
+        }
+    }
+}

--- a/src/test/java/org/semux/api/ApiHandlerErrorTest.java
+++ b/src/test/java/org/semux/api/ApiHandlerErrorTest.java
@@ -86,6 +86,8 @@ public class ApiHandlerErrorTest extends ApiHandlerTestBase {
                         "10", "_") }, // non-hexadecimal data
                 { format("/transfer?from=%s&to=%s&value=%s&fee=%s&data=%s", ADDRESS_PLACEHOLDER, randomHex(), "10",
                         "10", randomHex()) }, // hexadecimal data
+                { "/get_transaction_limits" },
+                { "/get_transaction_limits?type=XXX" },
         });
     }
 

--- a/src/test/java/org/semux/api/ApiHandlerTest.java
+++ b/src/test/java/org/semux/api/ApiHandlerTest.java
@@ -387,7 +387,6 @@ public class ApiHandlerTest extends ApiHandlerTestBase {
             assertTrue(response.success);
             assertEquals(config.maxTransactionDataSize(type), response.result.maxTransactionDataSize);
             assertEquals(config.minTransactionFee(), response.result.minTransactionFee);
-            assertEquals(config.minDelegateBurnAmount(), response.result.minDelegateBurnAmount);
         }
     }
 

--- a/src/test/java/org/semux/api/ApiHandlerTest.java
+++ b/src/test/java/org/semux/api/ApiHandlerTest.java
@@ -10,6 +10,7 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -385,8 +386,14 @@ public class ApiHandlerTest extends ApiHandlerTestBase {
             String uri = "/get_transaction_limits?type=" + type.toString();
             GetTransactionLimitsResponse response = request(uri, GetTransactionLimitsResponse.class);
             assertTrue(response.success);
-            assertEquals(config.maxTransactionDataSize(type), response.result.maxTransactionDataSize);
-            assertEquals(config.minTransactionFee(), response.result.minTransactionFee);
+            assertEquals(config.maxTransactionDataSize(type), response.result.maxTransactionDataSize.intValue());
+            assertEquals(config.minTransactionFee(), response.result.minTransactionFee.longValue());
+
+            if (type.equals(TransactionType.DELEGATE)) {
+                assertEquals(config.minDelegateBurnAmount(), response.result.minDelegateBurnAmount.longValue());
+            } else {
+                assertNull(response.result.minDelegateBurnAmount);
+            }
         }
     }
 

--- a/src/test/java/org/semux/api/ApiHandlerTest.java
+++ b/src/test/java/org/semux/api/ApiHandlerTest.java
@@ -41,6 +41,7 @@ import org.semux.api.response.GetLatestBlockResponse;
 import org.semux.api.response.GetPeersResponse;
 import org.semux.api.response.GetPendingTransactionsResponse;
 import org.semux.api.response.GetRootResponse;
+import org.semux.api.response.GetTransactionLimitsResponse;
 import org.semux.api.response.GetTransactionResponse;
 import org.semux.api.response.GetValidatorsResponse;
 import org.semux.api.response.GetVoteResponse;
@@ -376,6 +377,18 @@ public class ApiHandlerTest extends ApiHandlerTestBase {
         CreateAccountResponse response = request(uri, CreateAccountResponse.class);
         assertTrue(response.success);
         assertEquals(size + 1, wallet.getAccounts().size());
+    }
+
+    @Test
+    public void testGetTransactionLimits() throws IOException {
+        for (TransactionType type : TransactionType.values()) {
+            String uri = "/get_transaction_limits?type=" + type.toString();
+            GetTransactionLimitsResponse response = request(uri, GetTransactionLimitsResponse.class);
+            assertTrue(response.success);
+            assertEquals(config.maxTransactionDataSize(type), response.result.maxTransactionDataSize);
+            assertEquals(config.minTransactionFee(), response.result.minTransactionFee);
+            assertEquals(config.minDelegateBurnAmount(), response.result.minDelegateBurnAmount);
+        }
     }
 
     @Test


### PR DESCRIPTION
A general purpose API `/get_transaction_limits?type` to retrieve limitations on making a type of transaction is proposed in this pull request for #445 