### PR TITLE
API: Reuse object mapper

### DIFF
--- a/src/main/java/org/semux/api/ApiHandlerResponse.java
+++ b/src/main/java/org/semux/api/ApiHandlerResponse.java
@@ -33,12 +33,4 @@ public class ApiHandlerResponse {
         this.success = success;
         this.message = message;
     }
-
-    public String serialize() {
-        try {
-            return new ObjectMapper().writeValueAsString(this);
-        } catch (JsonProcessingException e) {
-            return "{\"success\":false,\"message\":\"Internal server error\"}";
-        }
-    }
 }


### PR DESCRIPTION
It's an anti pattern to have objects serialize
themselves.  Best practice is to reuse the
object mapper.  This allows for customization
down the road (pretty print, etc)