### PR TITLE
Add Peer#capabilities

### DIFF
--- a/src/main/java/org/semux/api/response/Types.java
+++ b/src/main/java/org/semux/api/response/Types.java
@@ -255,6 +255,9 @@ public class Types {
         @JsonProperty("latency")
         public final Long latency;
 
+        @JsonProperty("capabilities")
+        public final List<String> capabilities;
+
         public PeerType(
                 @JsonProperty("ip") String ip,
                 @JsonProperty("port") int port,
@@ -262,7 +265,8 @@ public class Types {
                 @JsonProperty("clientId") String clientId,
                 @JsonProperty("peerId") String peerId,
                 @JsonProperty("latestBlockNumber") long latestBlockNumber,
-                @JsonProperty("latency") long latency) {
+                @JsonProperty("latency") long latency,
+                @JsonProperty("capabilities") List<String> capabilities) {
             this.ip = ip;
             this.port = port;
             this.networkVersion = networkVersion;
@@ -270,6 +274,7 @@ public class Types {
             this.peerId = peerId;
             this.latestBlockNumber = latestBlockNumber;
             this.latency = latency;
+            this.capabilities = capabilities;
         }
 
         public PeerType(Peer peer) {
@@ -279,7 +284,8 @@ public class Types {
                     peer.getClientId(),
                     Hex.PREF + peer.getPeerId(),
                     peer.getLatestBlockNumber(),
-                    peer.getLatency());
+                    peer.getLatency(),
+                    peer.getCapabilities().toList());
         }
     }
 

--- a/src/main/java/org/semux/net/Capability.java
+++ b/src/main/java/org/semux/net/Capability.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2017 The Semux Developers
+ *
+ * Distributed under the MIT software license, see the accompanying file
+ * LICENSE or https://opensource.org/licenses/mit-license.php
+ */
+package org.semux.net;
+
+import org.semux.net.msg.ReasonCode;
+
+/**
+ * This enum represents the available capabilities in current version of Semux
+ * wallet.
+ */
+public enum Capability {
+
+    /**
+     * A mandatory capability. One peer should be disconnected by
+     * ${@link ReasonCode#INCOMPATIBLE_PROTOCOL} if the peer doesn't support this
+     * capability.
+     */
+    SEM;
+
+    // TODO: BATCH_SYNC
+
+    // TODO: FAST_SYNC
+
+    // TODO: DAPP
+
+    /**
+     * Creates a ${@link CapabilitySet} contains the currently supported
+     * capabilities.
+     *
+     * @return a ${@link CapabilitySet} contains the currently supported
+     *         capabilities.
+     */
+    public static CapabilitySet supported() {
+        return CapabilitySet.of(SEM);
+    }
+}

--- a/src/main/java/org/semux/net/Capability.java
+++ b/src/main/java/org/semux/net/Capability.java
@@ -28,13 +28,12 @@ public enum Capability {
     // TODO: DAPP
 
     /**
-     * Creates a ${@link CapabilitySet} contains the currently supported
-     * capabilities.
-     *
-     * @return a ${@link CapabilitySet} contains the currently supported
-     *         capabilities.
+     * The maximum number of capabilities that can be supported.
      */
-    public static CapabilitySet supported() {
-        return CapabilitySet.of(SEM);
-    }
+    public static final int MAX_NUMBER_OF_CAPABILITIES = 128;
+
+    /**
+     * Currently supported capabilities.
+     */
+    public static final CapabilitySet SUPPORTED = CapabilitySet.of(SEM);
 }

--- a/src/main/java/org/semux/net/CapabilitySet.java
+++ b/src/main/java/org/semux/net/CapabilitySet.java
@@ -13,16 +13,15 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+/**
+ * An immutable set of capabilities.
+ */
 public class CapabilitySet {
 
-    /**
-     * A set of ${@link String} which represents the capabilities a ${@link Peer}
-     * supports.
-     */
-    private Set<String> capabilities;
+    private final Set<String> capabilities;
 
-    /** Do not instantiate CapabilitySet. */
-    private CapabilitySet() {
+    private CapabilitySet(Set<String> capabilities) {
+        this.capabilities = capabilities;
     }
 
     /**
@@ -31,9 +30,7 @@ public class CapabilitySet {
      * @return an empty and immutable ${@link CapabilitySet}
      */
     public static CapabilitySet emptySet() {
-        CapabilitySet capabilitySet = new CapabilitySet();
-        capabilitySet.capabilities = Collections.emptySet();
-        return capabilitySet;
+        return new CapabilitySet(Collections.emptySet());
     }
 
     /**
@@ -45,10 +42,8 @@ public class CapabilitySet {
      *         ${@link Capability}
      */
     public static CapabilitySet of(Capability... capabilityList) {
-        CapabilitySet capabilitySet = new CapabilitySet();
-        capabilitySet.capabilities = Arrays.stream(capabilityList).map(Capability::toString)
-                .collect(Collectors.toSet());
-        return capabilitySet;
+        return new CapabilitySet(Arrays.stream(capabilityList).map(Capability::toString)
+                .collect(Collectors.toSet()));
     }
 
     /**
@@ -60,9 +55,7 @@ public class CapabilitySet {
      *         ${@link String}.
      */
     public static CapabilitySet of(String... capabilityList) {
-        CapabilitySet capabilitySet = new CapabilitySet();
-        capabilitySet.capabilities = Arrays.stream(capabilityList).collect(Collectors.toSet());
-        return capabilitySet;
+        return new CapabilitySet(Arrays.stream(capabilityList).collect(Collectors.toSet()));
     }
 
     /**

--- a/src/main/java/org/semux/net/CapabilitySet.java
+++ b/src/main/java/org/semux/net/CapabilitySet.java
@@ -1,0 +1,107 @@
+/**
+ * Copyright (c) 2017 The Semux Developers
+ *
+ * Distributed under the MIT software license, see the accompanying file
+ * LICENSE or https://opensource.org/licenses/mit-license.php
+ */
+package org.semux.net;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class CapabilitySet {
+
+    /**
+     * A set of ${@link String} which represents the capabilities a ${@link Peer}
+     * supports.
+     */
+    private Set<String> capabilities;
+
+    /** Do not instantiate CapabilitySet. */
+    private CapabilitySet() {
+    }
+
+    /**
+     * Creates an empty and immutable ${@link CapabilitySet}
+     *
+     * @return an empty and immutable ${@link CapabilitySet}
+     */
+    public static CapabilitySet emptySet() {
+        CapabilitySet capabilitySet = new CapabilitySet();
+        capabilitySet.capabilities = Collections.emptySet();
+        return capabilitySet;
+    }
+
+    /**
+     * Converts a list of ${@link Capability} into a ${@link CapabilitySet}.
+     *
+     * @param capabilityList
+     *            a list of ${@link Capability}
+     * @return a ${@link CapabilitySet} contains the provided list of
+     *         ${@link Capability}
+     */
+    public static CapabilitySet of(Capability... capabilityList) {
+        CapabilitySet capabilitySet = new CapabilitySet();
+        capabilitySet.capabilities = Arrays.stream(capabilityList).map(Capability::toString)
+                .collect(Collectors.toSet());
+        return capabilitySet;
+    }
+
+    /**
+     * Converts a list of String into a ${@link CapabilitySet}.
+     *
+     * @param capabilityList
+     *            a list of ${@link String}
+     * @return a ${@link CapabilitySet} contains the provided list of
+     *         ${@link String}.
+     */
+    public static CapabilitySet of(String... capabilityList) {
+        CapabilitySet capabilitySet = new CapabilitySet();
+        capabilitySet.capabilities = Arrays.stream(capabilityList).collect(Collectors.toSet());
+        return capabilitySet;
+    }
+
+    /**
+     * Checks whether the capability is supported by the ${@link CapabilitySet}.
+     *
+     * @param capability
+     *            the ${@link Capability} to be checked.
+     * @return true if the capability is supported, false if not
+     */
+    public boolean isSupported(Capability capability) {
+        return capabilities.contains(capability.toString());
+    }
+
+    /**
+     *
+     * @return the number of capabilities in the ${@link CapabilitySet}.
+     */
+    public int size() {
+        return capabilities.size();
+    }
+
+    /**
+     * Converts the ${@link CapabilitySet} to a list of String.
+     *
+     * @return a list of capabilities in ${@link String}
+     */
+    public List<String> toList() {
+        return capabilities.stream().sorted().collect(Collectors.toList());
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean equals(Object object) {
+        return object instanceof CapabilitySet && capabilities.equals(((CapabilitySet) object).capabilities);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public int hashCode() {
+        return Objects.hash(capabilities);
+    }
+}

--- a/src/main/java/org/semux/net/Peer.java
+++ b/src/main/java/org/semux/net/Peer.java
@@ -67,7 +67,7 @@ public class Peer {
                 && clientId != null && clientId.length() < 128
                 && peerId != null && peerId.length() == 40
                 && latestBlockNumber >= 0
-                && capabilities != null && capabilities.size() < MAX_NUMBER_OF_CAPABILITIES;
+                && capabilities != null && capabilities.size() <= MAX_NUMBER_OF_CAPABILITIES;
     }
 
     /**

--- a/src/main/java/org/semux/net/Peer.java
+++ b/src/main/java/org/semux/net/Peer.java
@@ -6,6 +6,8 @@
  */
 package org.semux.net;
 
+import static org.semux.net.Capability.MAX_NUMBER_OF_CAPABILITIES;
+
 import org.semux.util.SimpleDecoder;
 import org.semux.util.SimpleEncoder;
 
@@ -29,11 +31,6 @@ public class Peer {
      * Variables below are not persisted
      */
     private long latency;
-
-    /**
-     * The maximum number of capabilities a peer can support.
-     */
-    private static final int MAX_NUMBER_OF_CAPABILITIES = 128;
 
     /**
      * Set of capabilities the peer supports
@@ -70,7 +67,7 @@ public class Peer {
                 && clientId != null && clientId.length() < 128
                 && peerId != null && peerId.length() == 40
                 && latestBlockNumber >= 0
-                && capabilities != null;
+                && capabilities != null && capabilities.size() < MAX_NUMBER_OF_CAPABILITIES;
     }
 
     /**

--- a/src/main/java/org/semux/net/SemuxP2pHandler.java
+++ b/src/main/java/org/semux/net/SemuxP2pHandler.java
@@ -122,7 +122,7 @@ public class SemuxP2pHandler extends SimpleChannelInboundHandler<Message> {
         // send a HELLO message to initiate handshake
         if (!channel.isInbound()) {
             Peer peer = new Peer(client.getIp(), client.getPort(), config.networkVersion(), config.getClientId(),
-                    client.getPeerId(), chain.getLatestBlockNumber());
+                    client.getPeerId(), chain.getLatestBlockNumber(), Capability.supported());
             HelloMessage msg = new HelloMessage(peer, client.getCoinbase());
             msgQueue.sendMessage(msg);
         }
@@ -163,9 +163,8 @@ public class SemuxP2pHandler extends SimpleChannelInboundHandler<Message> {
             Peer peer = helloMsg.getPeer();
 
             ReasonCode error = null;
-            if (!isSupported(peer.getNetworkVersion())) {
+            if (!isSupported(peer.getNetworkVersion()) || !peer.getCapabilities().isSupported(Capability.SEM)) {
                 error = ReasonCode.INCOMPATIBLE_PROTOCOL;
-
             } else if (client.getPeerId().equals(peer.getPeerId()) || channelMgr.isActivePeer(peer.getPeerId())) {
                 error = ReasonCode.DUPLICATED_PEER_ID;
 
@@ -184,7 +183,7 @@ public class SemuxP2pHandler extends SimpleChannelInboundHandler<Message> {
 
                 // reply with a WORLD message
                 peer = new Peer(client.getIp(), client.getPort(), config.networkVersion(), config.getClientId(),
-                        client.getPeerId(), chain.getLatestBlockNumber());
+                        client.getPeerId(), chain.getLatestBlockNumber(), Capability.supported());
                 WorldMessage worldMsg = new WorldMessage(peer, client.getCoinbase());
                 msgQueue.sendMessage(worldMsg);
 

--- a/src/main/java/org/semux/net/SemuxP2pHandler.java
+++ b/src/main/java/org/semux/net/SemuxP2pHandler.java
@@ -122,7 +122,7 @@ public class SemuxP2pHandler extends SimpleChannelInboundHandler<Message> {
         // send a HELLO message to initiate handshake
         if (!channel.isInbound()) {
             Peer peer = new Peer(client.getIp(), client.getPort(), config.networkVersion(), config.getClientId(),
-                    client.getPeerId(), chain.getLatestBlockNumber(), Capability.supported());
+                    client.getPeerId(), chain.getLatestBlockNumber(), Capability.SUPPORTED);
             HelloMessage msg = new HelloMessage(peer, client.getCoinbase());
             msgQueue.sendMessage(msg);
         }
@@ -183,7 +183,7 @@ public class SemuxP2pHandler extends SimpleChannelInboundHandler<Message> {
 
                 // reply with a WORLD message
                 peer = new Peer(client.getIp(), client.getPort(), config.networkVersion(), config.getClientId(),
-                        client.getPeerId(), chain.getLatestBlockNumber(), Capability.supported());
+                        client.getPeerId(), chain.getLatestBlockNumber(), Capability.SUPPORTED);
                 WorldMessage worldMsg = new WorldMessage(peer, client.getCoinbase());
                 msgQueue.sendMessage(worldMsg);
 

--- a/src/test/java/org/semux/api/ApiHandlerTest.java
+++ b/src/test/java/org/semux/api/ApiHandlerTest.java
@@ -61,6 +61,7 @@ import org.semux.core.Unit;
 import org.semux.core.state.DelegateState;
 import org.semux.crypto.Hex;
 import org.semux.crypto.Key;
+import org.semux.net.Capability;
 import org.semux.net.Peer;
 import org.semux.net.filter.FilterRule;
 import org.semux.rules.KernelRule;
@@ -125,8 +126,9 @@ public class ApiHandlerTest extends ApiHandlerTestBase {
     @Test
     public void testGetPeers() throws IOException {
         channelMgr = spy(api.getKernel().getChannelManager());
-        List<Peer> peers = Arrays.asList(new Peer("1.2.3.4", 5161, (short) 1, "client1", "peer1", 1),
-                new Peer("2.3.4.5", 5171, (short) 2, "client2", "peer2", 2));
+        List<Peer> peers = Arrays.asList(
+                new Peer("1.2.3.4", 5161, (short) 1, "client1", "peer1", 1, Capability.supported()),
+                new Peer("2.3.4.5", 5171, (short) 2, "client2", "peer2", 2, Capability.supported()));
         when(channelMgr.getActivePeers()).thenReturn(peers);
         api.getKernel().setChannelManager(channelMgr);
 

--- a/src/test/java/org/semux/api/ApiHandlerTest.java
+++ b/src/test/java/org/semux/api/ApiHandlerTest.java
@@ -127,8 +127,8 @@ public class ApiHandlerTest extends ApiHandlerTestBase {
     public void testGetPeers() throws IOException {
         channelMgr = spy(api.getKernel().getChannelManager());
         List<Peer> peers = Arrays.asList(
-                new Peer("1.2.3.4", 5161, (short) 1, "client1", "peer1", 1, Capability.supported()),
-                new Peer("2.3.4.5", 5171, (short) 2, "client2", "peer2", 2, Capability.supported()));
+                new Peer("1.2.3.4", 5161, (short) 1, "client1", "peer1", 1, Capability.SUPPORTED),
+                new Peer("2.3.4.5", 5171, (short) 2, "client2", "peer2", 2, Capability.SUPPORTED));
         when(channelMgr.getActivePeers()).thenReturn(peers);
         api.getKernel().setChannelManager(channelMgr);
 

--- a/src/test/java/org/semux/api/ApiHandlerTest.java
+++ b/src/test/java/org/semux/api/ApiHandlerTest.java
@@ -148,6 +148,7 @@ public class ApiHandlerTest extends ApiHandlerTestBase {
             assertEquals(Hex.PREF + peer.getPeerId(), peerJson.peerId);
             assertEquals(peer.getLatestBlockNumber(), peerJson.latestBlockNumber.longValue());
             assertEquals(peer.getLatency(), peerJson.latency.longValue());
+            assertEquals(peer.getCapabilities().toList(), peerJson.capabilities);
         }
     }
 

--- a/src/test/java/org/semux/net/CapabilityTest.java
+++ b/src/test/java/org/semux/net/CapabilityTest.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2017 The Semux Developers
+ *
+ * Distributed under the MIT software license, see the accompanying file
+ * LICENSE or https://opensource.org/licenses/mit-license.php
+ */
 package org.semux.net;
 
 import static org.junit.Assert.assertFalse;

--- a/src/test/java/org/semux/net/CapabilityTest.java
+++ b/src/test/java/org/semux/net/CapabilityTest.java
@@ -1,0 +1,17 @@
+package org.semux.net;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class CapabilityTest {
+
+    @Test
+    public void testIsSupported() {
+        assertFalse(CapabilitySet.emptySet().isSupported(Capability.SEM));
+        assertFalse(CapabilitySet.of("ETH").isSupported(Capability.SEM));
+        assertTrue(CapabilitySet.of("SEM").isSupported(Capability.SEM));
+        assertTrue(CapabilitySet.of(Capability.SEM).isSupported(Capability.SEM));
+    }
+}

--- a/src/test/java/org/semux/net/PeerTest.java
+++ b/src/test/java/org/semux/net/PeerTest.java
@@ -22,7 +22,7 @@ public class PeerTest {
         String peerId = new Key().toAddressString();
         long latestBlockNumber = 1;
 
-        Peer peer = new Peer(ip, port, p2pVersion, clientId, peerId, latestBlockNumber);
+        Peer peer = new Peer(ip, port, p2pVersion, clientId, peerId, latestBlockNumber, Capability.supported());
         peer = Peer.fromBytes(peer.toBytes());
 
         assertEquals(ip, peer.getIp());
@@ -31,5 +31,6 @@ public class PeerTest {
         assertEquals(clientId, peer.getClientId());
         assertEquals(peerId, peer.getPeerId());
         assertEquals(latestBlockNumber, peer.getLatestBlockNumber());
+        assertEquals(Capability.supported(), peer.getCapabilities());
     }
 }

--- a/src/test/java/org/semux/net/PeerTest.java
+++ b/src/test/java/org/semux/net/PeerTest.java
@@ -22,7 +22,7 @@ public class PeerTest {
         String peerId = new Key().toAddressString();
         long latestBlockNumber = 1;
 
-        Peer peer = new Peer(ip, port, p2pVersion, clientId, peerId, latestBlockNumber, Capability.supported());
+        Peer peer = new Peer(ip, port, p2pVersion, clientId, peerId, latestBlockNumber, Capability.SUPPORTED);
         peer = Peer.fromBytes(peer.toBytes());
 
         assertEquals(ip, peer.getIp());
@@ -31,6 +31,6 @@ public class PeerTest {
         assertEquals(clientId, peer.getClientId());
         assertEquals(peerId, peer.getPeerId());
         assertEquals(latestBlockNumber, peer.getLatestBlockNumber());
-        assertEquals(Capability.supported(), peer.getCapabilities());
+        assertEquals(Capability.SUPPORTED, peer.getCapabilities());
     }
 }

--- a/src/test/java/org/semux/net/msg/p2p/HelloMessageTest.java
+++ b/src/test/java/org/semux/net/msg/p2p/HelloMessageTest.java
@@ -14,6 +14,7 @@ import org.semux.config.Config;
 import org.semux.config.Constants;
 import org.semux.config.DevnetConfig;
 import org.semux.crypto.Key;
+import org.semux.net.Capability;
 import org.semux.net.Peer;
 
 public class HelloMessageTest {
@@ -24,7 +25,8 @@ public class HelloMessageTest {
 
         Key key = new Key();
         String peerId = key.toAddressString();
-        Peer peer = new Peer("127.0.0.1", 5161, config.networkVersion(), config.getClientId(), peerId, 2);
+        Peer peer = new Peer("127.0.0.1", 5161, config.networkVersion(), config.getClientId(), peerId, 2,
+                Capability.supported());
 
         HelloMessage msg = new HelloMessage(peer, key);
         assertTrue(msg.validate(config));

--- a/src/test/java/org/semux/net/msg/p2p/HelloMessageTest.java
+++ b/src/test/java/org/semux/net/msg/p2p/HelloMessageTest.java
@@ -26,7 +26,7 @@ public class HelloMessageTest {
         Key key = new Key();
         String peerId = key.toAddressString();
         Peer peer = new Peer("127.0.0.1", 5161, config.networkVersion(), config.getClientId(), peerId, 2,
-                Capability.supported());
+                Capability.SUPPORTED);
 
         HelloMessage msg = new HelloMessage(peer, key);
         assertTrue(msg.validate(config));

--- a/src/test/java/org/semux/net/msg/p2p/WorldMessageTest.java
+++ b/src/test/java/org/semux/net/msg/p2p/WorldMessageTest.java
@@ -26,7 +26,7 @@ public class WorldMessageTest {
         Key key = new Key();
         String peerId = key.toAddressString();
         Peer peer = new Peer("127.0.0.1", 5161, config.networkVersion(), config.getClientId(), peerId, 2,
-                Capability.supported());
+                Capability.SUPPORTED);
 
         WorldMessage msg = new WorldMessage(peer, key);
         assertTrue(msg.validate(config));

--- a/src/test/java/org/semux/net/msg/p2p/WorldMessageTest.java
+++ b/src/test/java/org/semux/net/msg/p2p/WorldMessageTest.java
@@ -14,6 +14,7 @@ import org.semux.config.Config;
 import org.semux.config.Constants;
 import org.semux.config.DevnetConfig;
 import org.semux.crypto.Key;
+import org.semux.net.Capability;
 import org.semux.net.Peer;
 
 public class WorldMessageTest {
@@ -24,7 +25,8 @@ public class WorldMessageTest {
 
         Key key = new Key();
         String peerId = key.toAddressString();
-        Peer peer = new Peer("127.0.0.1", 5161, config.networkVersion(), config.getClientId(), peerId, 2);
+        Peer peer = new Peer("127.0.0.1", 5161, config.networkVersion(), config.getClientId(), peerId, 2,
+                Capability.supported());
 
         WorldMessage msg = new WorldMessage(peer, key);
         assertTrue(msg.validate(config));


### PR DESCRIPTION
This pull request improves backward-compatibility of the P2P network protocol by allowing developers to add new message types without changing the number of `networkVersion`. There is now only a single mandatory capability `SEM`. In the future, we may like to introduce a few more capabilities such as batch synchronization and fast synchronization which can be implemented without breaking previous versions of Semux wallet.