### PR TITLE
Config: Use rolling file appender

### DIFF
--- a/config/log4j2.xml
+++ b/config/log4j2.xml
@@ -5,11 +5,13 @@
         <Console name="Console" target="SYSTEM_OUT">
             <PatternLayout pattern="%d{HH:mm:ss.SSS} %highlight{%-8level} %-16logger{0} %msg%n"/>
         </Console>
-        <File name="File" fileName="${sys:log.file}">
+        <RollingFile name="File" fileName="${sys:log.file}" filePattern="${sys:log.file}-%d{MM-dd-yyyy}.log.zip"
+                     ignoreExceptions="false">
             <append>true</append>
             <createOnDemand>true</createOnDemand>
             <PatternLayout pattern="%d{yyyy-MM-dd'T'HH:mm:ssZ} %-8level %-16logger{0} %msg%n"/>
-        </File>
+            <TimeBasedTriggeringPolicy/>
+        </RollingFile>
         <Async name="Async">
             <AppenderRef ref="File" />
             <AppenderRef ref="Console"/>


### PR DESCRIPTION
When running a delegate, logging can become
large and unwieldy.  It is good to keep logs
manageable.

Also will allow users to post relevant log files
without posting 100's of MB of logs.

This will roll logs once per day.  We can also
add a max number of logs to retain.