### PR TITLE
Exit Process When There's an Uncaught Exception During Kernel Startup

### DIFF
--- a/src/main/java/org/semux/cli/SemuxCli.java
+++ b/src/main/java/org/semux/cli/SemuxCli.java
@@ -170,7 +170,12 @@ public class SemuxCli extends Launcher {
         }
 
         // start kernel
-        startKernel(getConfig(), wallet, wallet.getAccount(getCoinbase()));
+        try {
+            startKernel(getConfig(), wallet, wallet.getAccount(getCoinbase()));
+        } catch (Exception e) {
+            logger.error("Uncaught exception during kernel startup.", e);
+            SystemUtil.exitAsync(-1);
+        }
     }
 
     protected Kernel startKernel(Config config, Wallet wallet, Key coinbase) {

--- a/src/main/java/org/semux/gui/SemuxGui.java
+++ b/src/main/java/org/semux/gui/SemuxGui.java
@@ -208,7 +208,17 @@ public class SemuxGui extends Launcher {
             setCoinbase(0);
         }
 
-        startKernelAndMain(wallet);
+        try {
+            startKernelAndMain(wallet);
+        } catch (Exception e) {
+            JOptionPane.showMessageDialog(
+                    null,
+                    e.getMessage(),
+                    GuiMessages.get("ErrorDialogTitle"),
+                    JOptionPane.ERROR_MESSAGE);
+            logger.error("Uncaught exception during kernel startup.", e);
+            SystemUtil.exitAsync(-1);
+        }
     }
 
     /**

--- a/src/main/java/org/semux/net/filter/SemuxIpFilter.java
+++ b/src/main/java/org/semux/net/filter/SemuxIpFilter.java
@@ -230,7 +230,6 @@ public class SemuxIpFilter {
             } catch (IOException e) {
                 throw new ParseException(e);
             }
-
         }
     }
 }


### PR DESCRIPTION
related to #511

#### Issue

Main process could be stuck when there is an uncaught exception during kernel startup.

#### Steps to reproduce the issue

1. make the content of `config/ipfilter.json` become an invalid JSON
2. start `semux-cli.sh` or `semux-gui.sh`