### PR TITLE
GUI: Error message on failure to add account

### DIFF
--- a/src/main/java/org/semux/gui/panel/ReceivePanel.java
+++ b/src/main/java/org/semux/gui/panel/ReceivePanel.java
@@ -300,12 +300,17 @@ public class ReceivePanel extends JPanel implements ActionListener {
 
         Wallet wallet = kernel.getWallet();
         wallet.addAccount(key);
-        wallet.flush();
+        boolean added = wallet.flush();
 
-        // fire update event
-        model.fireUpdateEvent();
+        if (added) {
+            // fire update event
+            model.fireUpdateEvent();
 
-        JOptionPane.showMessageDialog(this, GuiMessages.get("NewAccountCreated"));
+            JOptionPane.showMessageDialog(this, GuiMessages.get("NewAccountCreated"));
+        } else {
+            wallet.deleteAccount(key);
+            JOptionPane.showMessageDialog(this, GuiMessages.get("WalletSaveFailed"));
+        }
     }
 
     /**

--- a/src/main/resources/org/semux/gui/messages.properties
+++ b/src/main/resources/org/semux/gui/messages.properties
@@ -57,6 +57,7 @@ SyncFinished = finished
 # receive panel
 NewAccount = New Account
 NewAccountCreated = New account created!
+WalletSaveFailed = Unable to save wallet!
 AccountNumShort = Acc #{0}
 AccountNum = Account #{0}
 CopyAddress = Copy Address


### PR DESCRIPTION
If the wallet file fails to save, do not let users add
accounts.  They could transfer funds to it, and they will
be lost forever!

fixes #514