### PR TITLE
CLI: flush async loggers in Launcher class

### DIFF
--- a/src/main/java/org/semux/cli/SemuxCli.java
+++ b/src/main/java/org/semux/cli/SemuxCli.java
@@ -167,6 +167,7 @@ public class SemuxCli extends Launcher {
         if (getCoinbase() < 0 || getCoinbase() >= accounts.size()) {
             logger.error(CliMessages.get("CoinbaseDoesNotExist"));
             SystemUtil.exit(-1);
+            return;
         }
 
         // start kernel
@@ -276,12 +277,14 @@ public class SemuxCli extends Launcher {
             if (!accountAdded) {
                 logger.error(CliMessages.get("PrivateKeyAlreadyInWallet"));
                 SystemUtil.exit(1);
+                return;
             }
 
             boolean walletFlushed = wallet.flush();
             if (!walletFlushed) {
                 logger.error(CliMessages.get("WalletFileCannotBeUpdated"));
                 SystemUtil.exit(2);
+                return;
             }
 
             logger.info(CliMessages.get("PrivateKeyImportedSuccessfully"));

--- a/src/main/resources/org/semux/cli/messages.properties
+++ b/src/main/resources/org/semux/cli/messages.properties
@@ -28,3 +28,4 @@ CoinbaseDoesNotExist = Coinbase does not exist
 ListAccountItem = Account #{0} = {1}
 SpecifyNetwork = Specify the network: mainnet, testnet or devnet
 CreateNewWalletError = Unable to create a new wallet.
+WrongPassword = Incorrect password

--- a/src/test/java/org/semux/TestLoggingAppender.java
+++ b/src/test/java/org/semux/TestLoggingAppender.java
@@ -81,7 +81,17 @@ public final class TestLoggingAppender extends AbstractAppender {
         return log(Level.INFO, msg);
     }
 
-    protected static LogEvent log(Level lvl, String msg) {
+    /**
+     * Construct an ERROR {@link LogEvent}.
+     *
+     * @param msg
+     * @return
+     */
+    public static LogEvent err(String msg) {
+        return log(Level.ERROR, msg);
+    }
+
+    public static LogEvent log(Level lvl, String msg) {
         return new LogEventMini(lvl, msg);
     }
 

--- a/src/test/java/org/semux/cli/SemuxCliTest.java
+++ b/src/test/java/org/semux/cli/SemuxCliTest.java
@@ -23,6 +23,7 @@ import static org.powermock.api.mockito.PowerMockito.mockStatic;
 import static org.powermock.api.mockito.PowerMockito.spy;
 import static org.powermock.api.mockito.PowerMockito.when;
 import static org.powermock.api.mockito.PowerMockito.whenNew;
+import static org.semux.TestLoggingAppender.err;
 import static org.semux.TestLoggingAppender.info;
 
 import java.security.KeyPair;
@@ -95,6 +96,26 @@ public class SemuxCliTest {
         SemuxCli.main(args);
 
         verify(semuxCLI).start(args);
+    }
+
+    @Test
+    public void testLoadAndUnlockWalletWithWrongPassword() {
+        SemuxCli semuxCLI = spy(new SemuxCli());
+
+        // mock wallet
+        Wallet wallet = mock(Wallet.class);
+        when(wallet.unlock(any())).thenReturn(false);
+        when(semuxCLI.loadWallet()).thenReturn(wallet);
+
+        // mock password
+        when(semuxCLI.getPassword()).thenReturn("password");
+
+        // execution
+        exit.expectSystemExitWithStatus(-1);
+        semuxCLI.loadAndUnlockWallet();
+
+        // assertion
+        assertThat(TestLoggingAppender.events(), hasItem(err(CliMessages.get("WrongPassword"))));
     }
 
     @Test


### PR DESCRIPTION
To resolve #532. The change ensures that log4j async loggers will be flushed in JVM shutdown hook by moving `Runtime#addShutdownHook` from Kernel class to Launcher class.