### PR TITLE
API: Add sign/verify messages calls

### DIFF
--- a/src/main/java/org/semux/api/ApiHandlerImpl.java
+++ b/src/main/java/org/semux/api/ApiHandlerImpl.java
@@ -109,6 +109,12 @@ public class ApiHandlerImpl implements ApiHandler {
             case GET_TRANSACTION_LIMITS:
                 return getTransactionLimits(params);
 
+            case SIGN_MESSAGE:
+                return signMessage(params);
+
+            case VERIFY_MESSAGE:
+                return verifyMessage(params);
+
             case TRANSFER:
             case DELEGATE:
             case VOTE:
@@ -121,6 +127,26 @@ public class ApiHandlerImpl implements ApiHandler {
         } catch (Exception e) {
             return semuxApi.failure("Failed to process your request: " + e.getMessage());
         }
+    }
+
+    /**
+     * GET /verify_message?address&message&signature
+     * 
+     * @param params
+     * @return
+     */
+    private ApiHandlerResponse verifyMessage(Map<String, String> params) {
+        return semuxApi.verifyMessage(params.get("address"), params.get("message"), params.get("signature"));
+    }
+
+    /**
+     * GET /sign_message?address&message
+     *
+     * @param params
+     * @return
+     */
+    private ApiHandlerResponse signMessage(Map<String, String> params) {
+        return semuxApi.signMessage(params.get("address"), params.get("message"));
     }
 
     /**

--- a/src/main/java/org/semux/api/Command.java
+++ b/src/main/java/org/semux/api/Command.java
@@ -19,6 +19,11 @@ public enum Command {
      */
     GET_INFO,
 
+    /**
+     * Verify a message
+     */
+    VERIFY_MESSAGE,
+
     // =======================
     // network
     // =======================
@@ -143,6 +148,11 @@ public enum Command {
      * Register as a delegate.
      */
     DELEGATE,
+
+    /**
+     * Sign a message
+     */
+    SIGN_MESSAGE,
 
     /**
      * Vote for a delegate.

--- a/src/main/java/org/semux/api/SemuxApi.java
+++ b/src/main/java/org/semux/api/SemuxApi.java
@@ -33,6 +33,8 @@ import org.semux.api.response.GetVoteResponse;
 import org.semux.api.response.GetVotesResponse;
 import org.semux.api.response.ListAccountsResponse;
 import org.semux.api.response.SendTransactionResponse;
+import org.semux.api.response.SignMessageResponse;
+import org.semux.api.response.VerifyMessageResponse;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
@@ -211,5 +213,18 @@ public interface SemuxApi {
     @ApiOperation(value = "Get transaction limits", notes = "Get minimum fee and maximum size.", response = GetTransactionLimitsResponse.class)
     @Produces(JSON_MIME)
     ApiHandlerResponse getTransactionLimits(@QueryParam("type") String type);
+
+    @GET
+    @Path("sign_message")
+    @ApiOperation(value = "Sign a message", notes = "Sign a message.", response = SignMessageResponse.class)
+    @Produces(JSON_MIME)
+    ApiHandlerResponse signMessage(@QueryParam("address") String address, @QueryParam("message") String message);
+
+    @GET
+    @Path("verify_message")
+    @ApiOperation(value = "Verify a message", notes = "Verify a signed message.", response = VerifyMessageResponse.class)
+    @Produces(JSON_MIME)
+    ApiHandlerResponse verifyMessage(@QueryParam("address") String address, @QueryParam("message") String message,
+            @QueryParam("signature") String signature);
 
 }

--- a/src/main/java/org/semux/api/SemuxApiImpl.java
+++ b/src/main/java/org/semux/api/SemuxApiImpl.java
@@ -55,7 +55,6 @@ import org.semux.crypto.Key;
 import org.semux.crypto.cache.PublicKeyCache;
 import org.semux.net.NodeManager;
 import org.semux.net.filter.SemuxIpFilter;
-import org.semux.util.Bytes;
 
 public class SemuxApiImpl implements SemuxApi {
     private Kernel kernel;

--- a/src/main/java/org/semux/api/SemuxApiImpl.java
+++ b/src/main/java/org/semux/api/SemuxApiImpl.java
@@ -435,14 +435,15 @@ public class SemuxApiImpl implements SemuxApi {
             byte[] signatureAddress = Hash.h160(pubKey.getEncoded());
             byte[] addressBytes = Hex.decode0x(address);
 
+            boolean isValidSignature = true;
             if (!Arrays.equals(signatureAddress, addressBytes)) {
-                return failure("Signature does not match provided address.");
+                isValidSignature = false;
             }
             if (!Key.verify(message.getBytes(), sig)) {
-                return failure("Signature does not match message.");
+                isValidSignature = false;
             }
 
-            return new VerifyMessageResponse(true);
+            return new VerifyMessageResponse(true, isValidSignature);
         } catch (NullPointerException | IllegalArgumentException e) {
             return failure(String.format("Invalid Signature"));
         }

--- a/src/main/java/org/semux/api/SemuxApiImpl.java
+++ b/src/main/java/org/semux/api/SemuxApiImpl.java
@@ -439,19 +439,15 @@ public class SemuxApiImpl implements SemuxApi {
         if (signature == null) {
             return failure("Parameter `signature` is required");
         }
+        boolean isValidSignature = true;
+
         try {
             Key.Signature sig = Key.Signature.fromBytes(Hex.decode0x(signature));
             EdDSAPublicKey pubKey = PublicKeyCache.computeIfAbsent(sig.getPublicKey());
             byte[] signatureAddress = Hash.h160(pubKey.getEncoded());
 
             byte[] addressBytes;
-            try {
-                addressBytes = Hex.decode0x(address);
-            } catch (CryptoException ex) {
-                return failure("Parameter `address` is not a valid hexadecimal string");
-            }
-
-            boolean isValidSignature = true;
+            addressBytes = Hex.decode0x(address);
             if (!Arrays.equals(signatureAddress, addressBytes)) {
                 isValidSignature = false;
             }
@@ -459,10 +455,10 @@ public class SemuxApiImpl implements SemuxApi {
                 isValidSignature = false;
             }
 
-            return new VerifyMessageResponse(true, isValidSignature);
-        } catch (NullPointerException | IllegalArgumentException e) {
-            return failure(String.format("Invalid Signature"));
+        } catch (NullPointerException | IllegalArgumentException | CryptoException e) {
+            isValidSignature = false;
         }
+        return new VerifyMessageResponse(true, isValidSignature);
     }
 
     /**

--- a/src/main/java/org/semux/api/SemuxApiImpl.java
+++ b/src/main/java/org/semux/api/SemuxApiImpl.java
@@ -14,6 +14,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import net.i2p.crypto.eddsa.EdDSAPublicKey;
 import org.semux.Kernel;
 import org.semux.api.response.AddNodeResponse;
 import org.semux.api.response.CreateAccountResponse;
@@ -35,7 +36,9 @@ import org.semux.api.response.GetVoteResponse;
 import org.semux.api.response.GetVotesResponse;
 import org.semux.api.response.ListAccountsResponse;
 import org.semux.api.response.SendTransactionResponse;
+import org.semux.api.response.SignMessageResponse;
 import org.semux.api.response.Types;
+import org.semux.api.response.VerifyMessageResponse;
 import org.semux.api.util.TransactionBuilder;
 import org.semux.core.Block;
 import org.semux.core.BlockchainImpl;
@@ -46,10 +49,13 @@ import org.semux.core.exception.WalletLockedException;
 import org.semux.core.state.Account;
 import org.semux.core.state.Delegate;
 import org.semux.crypto.CryptoException;
+import org.semux.crypto.Hash;
 import org.semux.crypto.Hex;
 import org.semux.crypto.Key;
+import org.semux.crypto.cache.PublicKeyCache;
 import org.semux.net.NodeManager;
 import org.semux.net.filter.SemuxIpFilter;
+import org.semux.util.Bytes;
 
 public class SemuxApiImpl implements SemuxApi {
     private Kernel kernel;
@@ -391,6 +397,55 @@ public class SemuxApiImpl implements SemuxApi {
                     Arrays.stream(TransactionType.values())
                             .map(TransactionType::toString)
                             .collect(Collectors.joining(","))));
+        }
+    }
+
+    @Override
+    public ApiHandlerResponse signMessage(String address, String message) {
+        if (address == null) {
+            return failure("Parameter `address` can't be null");
+        }
+        if (message == null) {
+            return failure("Parameter `message` can't be null");
+        }
+        try {
+            byte[] addressBytes = Hex.decode0x(address);
+
+            Key account = kernel.getWallet().getAccount(addressBytes);
+            Key.Signature signedMessage = account.sign(message.getBytes());
+            return new SignMessageResponse(true, Hex.encode0x(signedMessage.toBytes()));
+        } catch (NullPointerException | IllegalArgumentException e) {
+            return failure("Invalid message");
+        }
+    }
+
+    @Override
+    public ApiHandlerResponse verifyMessage(String address, String message, String signature) {
+        if (address == null) {
+            return failure("Parameter `address` can't be null");
+        }
+        if (message == null) {
+            return failure("Parameter `message` can't be null");
+        }
+        if (signature == null) {
+            return failure("Parameter `signature` can't be null");
+        }
+        try {
+            Key.Signature sig = Key.Signature.fromBytes(Hex.decode0x(signature));
+            EdDSAPublicKey pubKey = PublicKeyCache.computeIfAbsent(sig.getPublicKey());
+            byte[] signatureAddress = Hash.h160(pubKey.getEncoded());
+            byte[] addressBytes = Hex.decode0x(address);
+
+            if (!Arrays.equals(signatureAddress, addressBytes)) {
+                return failure("Signature does not match provided address.");
+            }
+            if (!Key.verify(message.getBytes(), sig)) {
+                return failure("Signature does not match message.");
+            }
+
+            return new VerifyMessageResponse(true);
+        } catch (NullPointerException | IllegalArgumentException e) {
+            return failure(String.format("Invalid Signature"));
         }
     }
 

--- a/src/main/java/org/semux/api/response/SignMessageResponse.java
+++ b/src/main/java/org/semux/api/response/SignMessageResponse.java
@@ -6,8 +6,6 @@
  */
 package org.semux.api.response;
 
-import java.util.List;
-
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.semux.api.ApiHandlerResponse;
 

--- a/src/main/java/org/semux/api/response/SignMessageResponse.java
+++ b/src/main/java/org/semux/api/response/SignMessageResponse.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2017-2018 The Semux Developers
+ *
+ * Distributed under the MIT software license, see the accompanying file
+ * LICENSE or https://opensource.org/licenses/mit-license.php
+ */
+package org.semux.api.response;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.semux.api.ApiHandlerResponse;
+
+/**
+ */
+public class SignMessageResponse extends ApiHandlerResponse {
+
+    @JsonProperty("result")
+    public final String signature;
+
+    public SignMessageResponse(
+            @JsonProperty("success") Boolean success,
+            @JsonProperty("result") String signature) {
+        super(success, null);
+        this.signature = signature;
+    }
+}

--- a/src/main/java/org/semux/api/response/VerifyMessageResponse.java
+++ b/src/main/java/org/semux/api/response/VerifyMessageResponse.java
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) 2017-2018 The Semux Developers
+ *
+ * Distributed under the MIT software license, see the accompanying file
+ * LICENSE or https://opensource.org/licenses/mit-license.php
+ */
+package org.semux.api.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.semux.api.ApiHandlerResponse;
+
+/**
+ */
+public class VerifyMessageResponse extends ApiHandlerResponse {
+
+    public VerifyMessageResponse(
+            @JsonProperty("success") Boolean success) {
+        super(success, null);
+    }
+}

--- a/src/main/java/org/semux/api/response/VerifyMessageResponse.java
+++ b/src/main/java/org/semux/api/response/VerifyMessageResponse.java
@@ -13,8 +13,12 @@ import org.semux.api.ApiHandlerResponse;
  */
 public class VerifyMessageResponse extends ApiHandlerResponse {
 
+    @JsonProperty("result")
+    public final Boolean validSignature;
+
     public VerifyMessageResponse(
-            @JsonProperty("success") Boolean success) {
+            @JsonProperty("success") Boolean success, @JsonProperty("result") Boolean validSignature) {
         super(success, null);
+        this.validSignature = validSignature;
     }
 }

--- a/src/test/java/org/semux/api/ApiHandlerTest.java
+++ b/src/test/java/org/semux/api/ApiHandlerTest.java
@@ -143,16 +143,19 @@ public class ApiHandlerTest extends ApiHandlerTestBase {
         uri = "/verify_message?address=" + address + "&message=" + message + "&signature=" + signature;
         VerifyMessageResponse verifyMessageResponse = request(uri, VerifyMessageResponse.class);
         assertTrue(verifyMessageResponse.success);
+        assertTrue(verifyMessageResponse.validSignature);
 
         // verify no messing with fromaddress
         uri = "/verify_message?address=" + addressOther + "&message=" + message + "&signature=" + signature;
         verifyMessageResponse = request(uri, VerifyMessageResponse.class);
-        assertFalse(verifyMessageResponse.success);
+        assertTrue(verifyMessageResponse.success);
+        assertFalse(verifyMessageResponse.validSignature);
 
         // verify no messing with message
         uri = "/verify_message?address=" + addressOther + "&message=" + message + "hi" + "&signature=" + signature;
         verifyMessageResponse = request(uri, VerifyMessageResponse.class);
-        assertFalse(verifyMessageResponse.success);
+        assertTrue(verifyMessageResponse.success);
+        assertFalse(verifyMessageResponse.validSignature);
     }
 
     @Test

--- a/src/test/java/org/semux/api/ApiHandlerTest.java
+++ b/src/test/java/org/semux/api/ApiHandlerTest.java
@@ -51,7 +51,9 @@ import org.semux.api.response.GetVoteResponse;
 import org.semux.api.response.GetVotesResponse;
 import org.semux.api.response.ListAccountsResponse;
 import org.semux.api.response.SendTransactionResponse;
+import org.semux.api.response.SignMessageResponse;
 import org.semux.api.response.Types;
+import org.semux.api.response.VerifyMessageResponse;
 import org.semux.core.Block;
 import org.semux.core.Genesis;
 import org.semux.core.Genesis.Premine;
@@ -125,6 +127,32 @@ public class ApiHandlerTest extends ApiHandlerTestBase {
         assertEquals(Long.valueOf(0), response.info.latestBlockNumber);
         assertEquals(Integer.valueOf(0), response.info.activePeers);
         assertEquals(Integer.valueOf(0), response.info.pendingTransactions);
+    }
+
+    @Test
+    public void testSignatures() throws IOException {
+
+        String address = wallet.getAccount(0).toAddressString();
+        String addressOther = wallet.getAccount(1).toAddressString();
+
+        String message = "helloworld";
+        String uri = "/sign_message?address=0x" + address + "&message=" + message;
+        SignMessageResponse response = request(uri, SignMessageResponse.class);
+        assertTrue(response.success);
+        String signature = response.signature;
+        uri = "/verify_message?address=" + address + "&message=" + message + "&signature=" + signature;
+        VerifyMessageResponse verifyMessageResponse = request(uri, VerifyMessageResponse.class);
+        assertTrue(verifyMessageResponse.success);
+
+        // verify no messing with fromaddress
+        uri = "/verify_message?address=" + addressOther + "&message=" + message + "&signature=" + signature;
+        verifyMessageResponse = request(uri, VerifyMessageResponse.class);
+        assertFalse(verifyMessageResponse.success);
+
+        // verify no messing with message
+        uri = "/verify_message?address=" + addressOther + "&message=" + message + "hi" + "&signature=" + signature;
+        verifyMessageResponse = request(uri, VerifyMessageResponse.class);
+        assertFalse(verifyMessageResponse.success);
     }
 
     @Test


### PR DESCRIPTION
Use the existing signatures to construct signed messages
This allows users to verify they control a given wallet
for trust

fixes #509