### PR TITLE
Tools: disable macOS CI build due to instability of travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,11 +19,11 @@ matrix:
       script:
         - mvn test
 
-    # macOS tests
-    - os: osx
-      osx_image: xcode9.2
-      script:
-        - mvn test
+    # macOS tests are disabled due to instability of travis-ci
+    # - os: osx
+    #   osx_image: xcode9.2
+    #   script:
+    #     - mvn test
 
     # Docker tests
     - language: none


### PR DESCRIPTION
https://www.traviscistatus.com/incidents/1p7kw5hl4n1g