### PR TITLE
Util: Add prefix to address in generated QR Code

### DIFF
--- a/src/main/java/org/semux/api/SemuxApiImpl.java
+++ b/src/main/java/org/semux/api/SemuxApiImpl.java
@@ -106,6 +106,7 @@ public class SemuxApiImpl implements SemuxApi {
 
     /**
      * Whether a value is supplied
+     * 
      * @param value
      * @return
      */

--- a/src/main/java/org/semux/gui/panel/ReceivePanel.java
+++ b/src/main/java/org/semux/gui/panel/ReceivePanel.java
@@ -275,7 +275,8 @@ public class ReceivePanel extends JPanel implements ActionListener {
             WalletAccount acc = getSelectedAccount();
 
             if (acc != null) {
-                BufferedImage bi = SwingUtil.createQrImage("semux://" + acc.getKey().toAddressString(), QR_SIZE,
+                BufferedImage bi = SwingUtil.createQrImage("semux://" + Hex.PREF + acc.getKey().toAddressString(),
+                        QR_SIZE,
                         QR_SIZE);
                 qr.setIcon(new ImageIcon(bi));
             } else {


### PR DESCRIPTION
Added Hex.PREF to the Address used by the QR creation method.

Currently the address for in the QR image is without  0x -prefix.

resolves #546 
