### PR TITLE
Properly Separate Mainnet and Testnet

### DIFF
--- a/src/main/java/org/semux/api/SemuxApiImpl.java
+++ b/src/main/java/org/semux/api/SemuxApiImpl.java
@@ -106,6 +106,7 @@ public class SemuxApiImpl implements SemuxApi {
 
     /**
      * Whether a value is supplied
+     * 
      * @param value
      * @return
      */

--- a/src/main/java/org/semux/config/Config.java
+++ b/src/main/java/org/semux/config/Config.java
@@ -14,6 +14,7 @@ import java.util.Set;
 
 import org.semux.Network;
 import org.semux.core.TransactionType;
+import org.semux.net.CapabilitySet;
 import org.semux.net.NodeManager.Node;
 import org.semux.net.msg.MessageCode;
 
@@ -137,6 +138,13 @@ public interface Config {
      * @return
      */
     String getClientId();
+
+    /**
+     * Returns the set of capability.
+     *
+     * @return
+     */
+    CapabilitySet capabilitySet();
 
     // =========================
     // P2P

--- a/src/main/java/org/semux/config/DevnetConfig.java
+++ b/src/main/java/org/semux/config/DevnetConfig.java
@@ -6,12 +6,20 @@
  */
 package org.semux.config;
 
+import static org.semux.net.Capability.SEM_TESTNET;
+
 import org.semux.Network;
+import org.semux.net.CapabilitySet;
 
 public class DevnetConfig extends AbstractConfig {
 
     public DevnetConfig(String dataDir) {
         super(dataDir, Network.DEVNET, Constants.DEVNET_VERSION);
         this.netMaxInboundConnectionsPerIp = Integer.MAX_VALUE;
+    }
+
+    @Override
+    public CapabilitySet capabilitySet() {
+        return CapabilitySet.of(SEM_TESTNET);
     }
 }

--- a/src/main/java/org/semux/config/MainnetConfig.java
+++ b/src/main/java/org/semux/config/MainnetConfig.java
@@ -11,7 +11,7 @@ import static org.semux.net.Capability.SEM;
 import org.semux.Network;
 import org.semux.net.CapabilitySet;
 
-public class MainnetConfig extends AbstractConfig implements Config {
+public class MainnetConfig extends AbstractConfig {
 
     public MainnetConfig(String dataDir) {
         super(dataDir, Network.MAINNET, Constants.MAINNET_VERSION);

--- a/src/main/java/org/semux/config/MainnetConfig.java
+++ b/src/main/java/org/semux/config/MainnetConfig.java
@@ -6,11 +6,19 @@
  */
 package org.semux.config;
 
-import org.semux.Network;
+import static org.semux.net.Capability.SEM;
 
-public class MainnetConfig extends AbstractConfig {
+import org.semux.Network;
+import org.semux.net.CapabilitySet;
+
+public class MainnetConfig extends AbstractConfig implements Config {
 
     public MainnetConfig(String dataDir) {
         super(dataDir, Network.MAINNET, Constants.MAINNET_VERSION);
+    }
+
+    @Override
+    public CapabilitySet capabilitySet() {
+        return CapabilitySet.of(SEM);
     }
 }

--- a/src/main/java/org/semux/config/TestnetConfig.java
+++ b/src/main/java/org/semux/config/TestnetConfig.java
@@ -11,7 +11,7 @@ import static org.semux.net.Capability.SEM_TESTNET;
 import org.semux.Network;
 import org.semux.net.CapabilitySet;
 
-public class TestnetConfig extends AbstractConfig implements Config {
+public class TestnetConfig extends AbstractConfig {
 
     public TestnetConfig(String dataDir) {
         super(dataDir, Network.TESTNET, Constants.TESTNET_VERSION);

--- a/src/main/java/org/semux/config/TestnetConfig.java
+++ b/src/main/java/org/semux/config/TestnetConfig.java
@@ -6,11 +6,19 @@
  */
 package org.semux.config;
 
-import org.semux.Network;
+import static org.semux.net.Capability.SEM_TESTNET;
 
-public class TestnetConfig extends AbstractConfig {
+import org.semux.Network;
+import org.semux.net.CapabilitySet;
+
+public class TestnetConfig extends AbstractConfig implements Config {
 
     public TestnetConfig(String dataDir) {
         super(dataDir, Network.TESTNET, Constants.TESTNET_VERSION);
+    }
+
+    @Override
+    public CapabilitySet capabilitySet() {
+        return CapabilitySet.of(SEM_TESTNET);
     }
 }

--- a/src/main/java/org/semux/net/Capability.java
+++ b/src/main/java/org/semux/net/Capability.java
@@ -15,11 +15,16 @@ import org.semux.net.msg.ReasonCode;
 public enum Capability {
 
     /**
-     * A mandatory capability. One peer should be disconnected by
+     * A mandatory capability of Semux mainnet. One peer should be disconnected by
      * ${@link ReasonCode#INCOMPATIBLE_PROTOCOL} if the peer doesn't support this
      * capability.
      */
-    SEM;
+    SEM,
+
+    /**
+     * A mandatory capability of Semux testnet.
+     */
+    SEM_TESTNET;
 
     // TODO: BATCH_SYNC
 
@@ -31,9 +36,4 @@ public enum Capability {
      * The maximum number of capabilities that can be supported.
      */
     public static final int MAX_NUMBER_OF_CAPABILITIES = 128;
-
-    /**
-     * Currently supported capabilities.
-     */
-    public static final CapabilitySet SUPPORTED = CapabilitySet.of(SEM);
 }

--- a/src/test/java/org/semux/api/ApiHandlerTest.java
+++ b/src/test/java/org/semux/api/ApiHandlerTest.java
@@ -129,8 +129,8 @@ public class ApiHandlerTest extends ApiHandlerTestBase {
     public void testGetPeers() throws IOException {
         channelMgr = spy(api.getKernel().getChannelManager());
         List<Peer> peers = Arrays.asList(
-                new Peer("1.2.3.4", 5161, (short) 1, "client1", "peer1", 1, Capability.SUPPORTED),
-                new Peer("2.3.4.5", 5171, (short) 2, "client2", "peer2", 2, Capability.SUPPORTED));
+                new Peer("1.2.3.4", 5161, (short) 1, "client1", "peer1", 1, config.capabilitySet()),
+                new Peer("2.3.4.5", 5171, (short) 2, "client2", "peer2", 2, config.capabilitySet()));
         when(channelMgr.getActivePeers()).thenReturn(peers);
         api.getKernel().setChannelManager(channelMgr);
 

--- a/src/test/java/org/semux/net/PeerTest.java
+++ b/src/test/java/org/semux/net/PeerTest.java
@@ -22,7 +22,8 @@ public class PeerTest {
         String peerId = new Key().toAddressString();
         long latestBlockNumber = 1;
 
-        Peer peer = new Peer(ip, port, p2pVersion, clientId, peerId, latestBlockNumber, Capability.SUPPORTED);
+        Peer peer = new Peer(ip, port, p2pVersion, clientId, peerId, latestBlockNumber,
+                CapabilitySet.of(Capability.SEM));
         peer = Peer.fromBytes(peer.toBytes());
 
         assertEquals(ip, peer.getIp());
@@ -31,6 +32,6 @@ public class PeerTest {
         assertEquals(clientId, peer.getClientId());
         assertEquals(peerId, peer.getPeerId());
         assertEquals(latestBlockNumber, peer.getLatestBlockNumber());
-        assertEquals(Capability.SUPPORTED, peer.getCapabilities());
+        assertEquals(CapabilitySet.of(Capability.SEM), peer.getCapabilities());
     }
 }

--- a/src/test/java/org/semux/net/msg/p2p/HelloMessageTest.java
+++ b/src/test/java/org/semux/net/msg/p2p/HelloMessageTest.java
@@ -26,7 +26,7 @@ public class HelloMessageTest {
         Key key = new Key();
         String peerId = key.toAddressString();
         Peer peer = new Peer("127.0.0.1", 5161, config.networkVersion(), config.getClientId(), peerId, 2,
-                Capability.SUPPORTED);
+                config.capabilitySet());
 
         HelloMessage msg = new HelloMessage(peer, key);
         assertTrue(msg.validate(config));

--- a/src/test/java/org/semux/net/msg/p2p/WorldMessageTest.java
+++ b/src/test/java/org/semux/net/msg/p2p/WorldMessageTest.java
@@ -26,7 +26,7 @@ public class WorldMessageTest {
         Key key = new Key();
         String peerId = key.toAddressString();
         Peer peer = new Peer("127.0.0.1", 5161, config.networkVersion(), config.getClientId(), peerId, 2,
-                Capability.SUPPORTED);
+                config.capabilitySet());
 
         WorldMessage msg = new WorldMessage(peer, key);
         assertTrue(msg.validate(config));


### PR DESCRIPTION
#### Issue

As of v1.0.0 it is possible for a mainnet node to connect to a testnet node or the other way around.

#### Solution

A new mandatory capability `SEM_TESTNET` is created in place of `SEM` for testnet nodes.