### PR TITLE
GUI: add InputDialog to Windows TaskBar

### DIFF
--- a/src/main/java/org/semux/api/SemuxApiImpl.java
+++ b/src/main/java/org/semux/api/SemuxApiImpl.java
@@ -106,6 +106,7 @@ public class SemuxApiImpl implements SemuxApi {
 
     /**
      * Whether a value is supplied
+     * 
      * @param value
      * @return
      */

--- a/src/main/java/org/semux/gui/dialog/InputDialog.java
+++ b/src/main/java/org/semux/gui/dialog/InputDialog.java
@@ -32,7 +32,7 @@ public class InputDialog extends JDialog implements ActionListener {
     private String text;
 
     public InputDialog(JFrame parent, String message, boolean isPassword) {
-        super(parent, GuiMessages.get("Input"));
+        super(parent, GuiMessages.get("Input"), java.awt.Dialog.ModalityType.TOOLKIT_MODAL);
 
         JLabel labelLogo = new JLabel("");
         labelLogo.setIcon(SwingUtil.loadImage("logo", 96, 96));


### PR DESCRIPTION
Windows TaskBar lacks an entry or icon for the
InputDialog (Password entry)
Added java.awt.Dialog.ModalityType.TOOLKIT_MODAL
as an parameter to superConstructor

resolves #536