### PR TITLE
GUI: added feedback for empty names on address book entries

### DIFF
--- a/src/main/java/org/semux/api/SemuxApiImpl.java
+++ b/src/main/java/org/semux/api/SemuxApiImpl.java
@@ -106,6 +106,7 @@ public class SemuxApiImpl implements SemuxApi {
 
     /**
      * Whether a value is supplied
+     * 
      * @param value
      * @return
      */

--- a/src/main/java/org/semux/gui/dialog/AddressBookDialog.java
+++ b/src/main/java/org/semux/gui/dialog/AddressBookDialog.java
@@ -29,6 +29,7 @@ import javax.swing.JScrollPane;
 import javax.swing.JTable;
 import javax.swing.table.AbstractTableModel;
 
+import org.apache.commons.lang3.StringUtils;
 import org.semux.core.Wallet;
 import org.semux.crypto.Hex;
 import org.semux.crypto.Key;
@@ -167,9 +168,13 @@ public class AddressBookDialog extends JDialog implements ActionListener {
             break;
         case ADD_ADDRESS:
             String name = JOptionPane.showInputDialog(this, GuiMessages.get("Name"));
-            if (name != null) {
+            if (StringUtils.isEmpty(name)) {
+                JOptionPane.showMessageDialog(this, GuiMessages.get("InvalidName"));
+            } else {
                 String address = JOptionPane.showInputDialog(this, GuiMessages.get("Address"));
-                if (address != null) {
+                if (StringUtils.isEmpty(address)) {
+                    JOptionPane.showMessageDialog(this, GuiMessages.get("InvalidAddress"));
+                } else {
                     try {
                         byte[] addr = Hex.decode0x(address.trim());
                         if (addr.length != Key.ADDRESS_LEN) {
@@ -206,6 +211,7 @@ public class AddressBookDialog extends JDialog implements ActionListener {
         default:
             throw new UnreachableException();
         }
+
     }
 
     public void refresh() {

--- a/src/main/resources/org/semux/gui/messages.properties
+++ b/src/main/resources/org/semux/gui/messages.properties
@@ -176,3 +176,4 @@ AddressBook = Address book
 SelectAddress = Please select an address!
 AddAddress = Add an address
 InvalidAddress = Invalid address!
+InvalidName = Invalid name!


### PR DESCRIPTION
When adding a new entry to the address book, the handle cannot be
null or empty. Added a check and a Feedback Pane

resolves #573