### PR TITLE
Consensus: fix an issue that SemuxSync might be stuck forever as a validator

### DIFF
--- a/src/main/java/org/semux/consensus/SemuxSync.java
+++ b/src/main/java/org/semux/consensus/SemuxSync.java
@@ -298,7 +298,7 @@ public class SemuxSync implements SyncManager {
         }
 
         long latest = chain.getLatestBlockNumber();
-        if (latest + 1 == target.get()) {
+        if (latest + 1 >= target.get()) {
             stop();
             return; // This is important because stop() only notify
         }


### PR DESCRIPTION
fix #585

As a validator, the local blockchain might be ahead of synchronization target that makes `SemuxSync` stuck forever.