### PR TITLE
GUI: Render to highest precision

### DIFF
--- a/src/main/java/org/semux/gui/SwingUtil.java
+++ b/src/main/java/org/semux/gui/SwingUtil.java
@@ -311,6 +311,7 @@ public class SwingUtil {
         NumberFormat format = NumberFormat.getInstance();
         format.setMinimumFractionDigits(decimals);
         format.setMaximumFractionDigits(decimals);
+        format.setMinimumFractionDigits(0);
 
         return format.format(number);
     }
@@ -402,7 +403,7 @@ public class SwingUtil {
      * @return
      */
     public static String formatVote(long vote) {
-        return formatNumber(vote / (double) Unit.SEM);
+        return formatValue(vote, false);
     }
 
     /**

--- a/src/main/java/org/semux/gui/SwingUtil.java
+++ b/src/main/java/org/semux/gui/SwingUtil.java
@@ -309,9 +309,8 @@ public class SwingUtil {
      */
     public static String formatNumber(Number number, int decimals) {
         NumberFormat format = NumberFormat.getInstance();
-        format.setMinimumFractionDigits(decimals);
-        format.setMaximumFractionDigits(decimals);
         format.setMinimumFractionDigits(0);
+        format.setMaximumFractionDigits(decimals);
 
         return format.format(number);
     }


### PR DESCRIPTION
For delegates panel, we show 0 for < 1 sem
As we allow fractional SEM votes, we should show
to same precison as elsewhere.

Also only show precision to just number available.
So we will render 3 instead of 3.000 and 3.2 instead
of 3.200.  This can allow us to choose to render more
decimals if we want without cluttering UI if user only
uses full SEM.

this also helps where folks say they believe that other
validators with 'same' number of votes took their spot
when its likely just a fractional vote that pushed them over