### PR TITLE
API: add a parameter 'name' to /create_account

### DIFF
--- a/src/main/java/org/semux/api/ApiHandlerImpl.java
+++ b/src/main/java/org/semux/api/ApiHandlerImpl.java
@@ -104,7 +104,7 @@ public class ApiHandlerImpl implements ApiHandler {
                 return listAccounts();
 
             case CREATE_ACCOUNT:
-                return createAccount();
+                return createAccount(params);
 
             case GET_TRANSACTION_LIMITS:
                 return getTransactionLimits(params);
@@ -358,8 +358,8 @@ public class ApiHandlerImpl implements ApiHandler {
      *
      * @return
      */
-    private ApiHandlerResponse createAccount() {
-        return semuxApi.createAccount();
+    private ApiHandlerResponse createAccount(Map<String, String> params) {
+        return semuxApi.createAccount(params.getOrDefault("name", null));
     }
 
     /**

--- a/src/main/java/org/semux/api/SemuxApi.java
+++ b/src/main/java/org/semux/api/SemuxApi.java
@@ -189,7 +189,8 @@ public interface SemuxApi {
     @Path("create_account")
     @ApiOperation(value = "Create account", notes = "Creates a new account.", response = CreateAccountResponse.class)
     @Produces(JSON_MIME)
-    ApiHandlerResponse createAccount();
+    ApiHandlerResponse createAccount(
+            @ApiParam(value = "Assigned alias to the created account.", required = false) @QueryParam("name") String name);
 
     @GET
     @Path("transfer")

--- a/src/main/java/org/semux/api/SemuxApiImpl.java
+++ b/src/main/java/org/semux/api/SemuxApiImpl.java
@@ -370,10 +370,18 @@ public class SemuxApiImpl implements SemuxApi {
     }
 
     @Override
-    public ApiHandlerResponse createAccount() {
+    public ApiHandlerResponse createAccount(String name) {
         try {
+            // create an account
             Key key = new Key();
             kernel.getWallet().addAccount(key);
+
+            // set alias of the address
+            if (isSet(name)) {
+                kernel.getWallet().setAddressAlias(key.toAddress(), name);
+            }
+
+            // save the account
             kernel.getWallet().flush();
             return new CreateAccountResponse(true, Hex.PREF + key.toAddressString());
         } catch (WalletLockedException e) {

--- a/src/test/java/org/semux/api/ApiHandlerTest.java
+++ b/src/test/java/org/semux/api/ApiHandlerTest.java
@@ -25,6 +25,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map.Entry;
+import java.util.Optional;
 
 import org.junit.After;
 import org.junit.Before;
@@ -439,6 +440,18 @@ public class ApiHandlerTest extends ApiHandlerTestBase {
         CreateAccountResponse response = request(uri, CreateAccountResponse.class);
         assertTrue(response.success);
         assertEquals(size + 1, wallet.getAccounts().size());
+    }
+
+    @Test
+    public void testCreateAccountWithName() throws IOException {
+        int size = wallet.getAccounts().size();
+
+        String uri = "/create_account?name=test_name";
+        CreateAccountResponse response = request(uri, CreateAccountResponse.class);
+        assertTrue(response.success);
+        List<Key> accounts = wallet.getAccounts();
+        assertEquals(size + 1, accounts.size());
+        assertEquals(Optional.of("test_name"), wallet.getAddressAlias(accounts.get(size).toAddress()));
     }
 
     @Test


### PR DESCRIPTION
fix #604