### PR TITLE
Core: improve error reporting of UNVOTE transaction

### DIFF
--- a/src/main/java/org/semux/core/TransactionExecutor.java
+++ b/src/main/java/org/semux/core/TransactionExecutor.java
@@ -164,18 +164,23 @@ public class TransactionExecutor {
                 break;
             }
             case UNVOTE: {
-                if (fee <= available && value <= locked) {
-                    if (ds.unvote(from, to, value)) {
+                if (available < fee) {
+                    result.setError(Error.INSUFFICIENT_AVAILABLE);
+                    break;
+                }
 
-                        as.adjustAvailable(from, value - fee);
-                        as.adjustLocked(from, -value);
-
-                        result.setSuccess(true);
-                    } else {
-                        result.setError(Error.FAILED);
-                    }
-                } else {
+                if (locked < value) {
                     result.setError(Error.INSUFFICIENT_LOCKED);
+                    break;
+                }
+
+                if (ds.unvote(from, to, value)) {
+                    as.adjustAvailable(from, value - fee);
+                    as.adjustLocked(from, -value);
+
+                    result.setSuccess(true);
+                } else {
+                    result.setError(Error.FAILED);
                 }
                 break;
             }


### PR DESCRIPTION
return `INSUFFICIENT_ERROR` in place of `INSUFFICIENT_LOCKED` when there is no enough available balance for paying tx fee