### PR TITLE
Consensus: fix unconditional wait of SemuxSync#isRunning

### DIFF
--- a/src/main/java/org/semux/consensus/SemuxSync.java
+++ b/src/main/java/org/semux/consensus/SemuxSync.java
@@ -144,7 +144,7 @@ public class SemuxSync implements SyncManager {
             while (isRunning.get()) {
                 synchronized (isRunning) {
                     try {
-                        isRunning.wait();
+                        isRunning.wait(1000);
                     } catch (InterruptedException e) {
                         Thread.currentThread().interrupt();
                         logger.info("Sync manager got interrupted");


### PR DESCRIPTION
To resolve: #585 

As a validator, `SemuxSync#process` could trigger `SemuxSync#stop` in its first scheduled execution:
https://github.com/semuxproject/semux/blob/e08bf781df8181362083a97224b48c9c5fdac9b3/src/main/java/org/semux/consensus/SemuxSync.java#L295-L304

which can be prior to the call of `SemuxSync#isRunning.wait()` in some rare cases, making `SemuxSync#isRunning` wait forever:
https://github.com/semuxproject/semux/blob/e08bf781df8181362083a97224b48c9c5fdac9b3/src/main/java/org/semux/consensus/SemuxSync.java#L139-L154

The pull request adds a timeout of 1 second to the call of `SemuxSync#isRunning.wait()`.

This issue is discovered by FindBugs, see http://findbugs.sourceforge.net/bugDescriptions.html#UW_UNCOND_WAIT