### PR TITLE
GUI: clean up address label

### DIFF
--- a/src/main/java/org/semux/gui/panel/ReceivePanel.java
+++ b/src/main/java/org/semux/gui/panel/ReceivePanel.java
@@ -276,8 +276,7 @@ public class ReceivePanel extends JPanel implements ActionListener {
 
             if (acc != null) {
                 BufferedImage bi = SwingUtil.createQrImage("semux://" + Hex.PREF + acc.getKey().toAddressString(),
-                        QR_SIZE,
-                        QR_SIZE);
+                        QR_SIZE, QR_SIZE);
                 qr.setIcon(new ImageIcon(bi));
             } else {
                 qr.setIcon(SwingUtil.emptyImage(QR_SIZE, QR_SIZE));
@@ -360,6 +359,7 @@ public class ReceivePanel extends JPanel implements ActionListener {
             if (ret == JOptionPane.OK_OPTION) {
                 Wallet wallet = kernel.getWallet();
                 wallet.removeAccount(acc.getKey());
+                wallet.removeAddressAlias(acc.getAddress());
                 wallet.flush();
 
                 // fire update event

--- a/src/main/java/org/semux/gui/panel/ReceivePanel.java
+++ b/src/main/java/org/semux/gui/panel/ReceivePanel.java
@@ -200,7 +200,7 @@ public class ReceivePanel extends JPanel implements ActionListener {
             case 0:
                 return SwingUtil.formatNumber(row);
             case 1:
-                return acc.getName().orElseGet(() -> "");
+                return acc.getName().orElse("");
             case 2:
                 return Hex.PREF + acc.getKey().toAddressString();
             case 3:


### PR DESCRIPTION
* Clean up how address label is computed in transaction description.
```
alias => delegate name => abbreviation
```
* Remove the alias when removing an account