### PR TITLE
GUI: link size of ReceivePanel#btnRenameAddress with other btns

### DIFF
--- a/src/main/java/org/semux/gui/panel/ReceivePanel.java
+++ b/src/main/java/org/semux/gui/panel/ReceivePanel.java
@@ -147,7 +147,7 @@ public class ReceivePanel extends JPanel implements ActionListener {
                                 .addContainerGap(249, Short.MAX_VALUE))
                         .addComponent(scrollPane, GroupLayout.DEFAULT_SIZE, 537, Short.MAX_VALUE)
         );
-        groupLayout.linkSize(SwingConstants.HORIZONTAL, btnCopyAddress, buttonNewAccount, btnDeleteAddress);
+        groupLayout.linkSize(SwingConstants.HORIZONTAL, btnCopyAddress, btnRenameAddress, buttonNewAccount, btnDeleteAddress);
         setLayout(groupLayout);
         // @formatter:on
 


### PR DESCRIPTION
fix #632 

![selection_199](https://user-images.githubusercontent.com/32390172/35731535-e70d5ac8-0850-11e8-9218-f56a95d85848.png)
