### PR TITLE
Net: Allow for additional DNS seeds

### DIFF
--- a/config/semux.properties
+++ b/config/semux.properties
@@ -44,6 +44,10 @@ net.relayRedundancy = 16
 # Channel idle timeout, ms
 net.channelIdleTimeout = 120000
 
+# DNS Seed (comma delimited)
+net.dnsSeeds.mainNet = mainnet.semux.org
+net.dnsSeeds.testNet = testnet.semux.org
+
 #================
 # API
 #================

--- a/src/main/java/org/semux/config/AbstractConfig.java
+++ b/src/main/java/org/semux/config/AbstractConfig.java
@@ -9,6 +9,7 @@ package org.semux.config;
 import java.io.File;
 import java.io.FileInputStream;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
@@ -74,6 +75,8 @@ public abstract class AbstractConfig implements Config {
             MessageCode.BFT_NEW_VIEW,
             MessageCode.BFT_PROPOSAL,
             MessageCode.BFT_VOTE));
+    protected List<String> netDnsSeedsMainNet = Collections.singletonList("mainnet.semux.org");
+    protected List<String> netDnsSeedsTestNet = Collections.singletonList("testnet.semux.org");
 
     // =========================
     // API
@@ -304,6 +307,16 @@ public abstract class AbstractConfig implements Config {
     }
 
     @Override
+    public List<String> netDnsSeedsMainNet() {
+        return netDnsSeedsMainNet;
+    }
+
+    @Override
+    public List<String> netDnsSeedsTestNet() {
+        return netDnsSeedsTestNet;
+    }
+
+    @Override
     public boolean apiEnabled() {
         return apiEnabled;
     }
@@ -439,6 +452,12 @@ public abstract class AbstractConfig implements Config {
                     break;
                 case "net.channelIdleTimeout":
                     netChannelIdleTimeout = Integer.parseInt(props.getProperty(name).trim());
+                    break;
+                case "net.dnsSeeds.mainNet":
+                    netDnsSeedsMainNet = Arrays.asList(props.getProperty(name).trim().split(","));
+                    break;
+                case "net.dnsSeeds.testNet":
+                    netDnsSeedsTestNet = Arrays.asList(props.getProperty(name).trim().split(","));
                     break;
 
                 case "api.enabled":

--- a/src/main/java/org/semux/config/Config.java
+++ b/src/main/java/org/semux/config/Config.java
@@ -249,6 +249,20 @@ public interface Config {
      */
     Set<MessageCode> netPrioritizedMessages();
 
+    /**
+     * Returns a list of DNS seeds for main network
+     *
+     * @return
+     */
+    List<String> netDnsSeedsMainNet();
+
+    /**
+     * Returns a list of DNS seeds for test network
+     *
+     * @return
+     */
+    List<String> netDnsSeedsTestNet();
+
     // =========================
     // API
     // =========================

--- a/src/main/java/org/semux/net/NodeManager.java
+++ b/src/main/java/org/semux/net/NodeManager.java
@@ -12,6 +12,7 @@ import java.net.UnknownHostException;
 import java.util.Collection;
 import java.util.Deque;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.Executors;
@@ -21,15 +22,14 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import org.semux.Kernel;
 import org.semux.Network;
 import org.semux.config.Config;
 import org.semux.config.Constants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.github.benmanes.caffeine.cache.Cache;
-import com.github.benmanes.caffeine.cache.Caffeine;
 
 public class NodeManager {
 
@@ -43,9 +43,6 @@ public class NodeManager {
             return new Thread(r, "node-" + cnt.getAndIncrement());
         }
     };
-
-    private static final String DNS_SEED_MAINNET = "mainnet.semux.org";
-    private static final String DNS_SEED_TESTNET = "testnet.semux.org";
 
     private static final long MAX_QUEUE_SIZE = 1024;
     private static final int LRU_CACHE_SIZE = 1024;
@@ -159,27 +156,29 @@ public class NodeManager {
      * @param network
      * @return
      */
-    public static Set<Node> getSeedNodes(Network network) {
+    public Set<Node> getSeedNodes(Network network) {
         Set<Node> nodes = new HashSet<>();
 
-        try {
-            String name;
-            switch (network) {
-            case MAINNET:
-                name = DNS_SEED_MAINNET;
-                break;
-            case TESTNET:
-                name = DNS_SEED_TESTNET;
-                break;
-            default:
-                return nodes;
-            }
+        List<String> names;
+        switch (network) {
+        case MAINNET:
+            names = kernel.getConfig().netDnsSeedsMainNet();
+            break;
+        case TESTNET:
+            names = kernel.getConfig().netDnsSeedsTestNet();
+            break;
+        default:
+            return nodes;
+        }
 
-            for (InetAddress a : InetAddress.getAllByName(name)) {
-                nodes.add(new Node(a, Constants.DEFAULT_P2P_PORT));
+        for (String name : names) {
+            try {
+                for (InetAddress a : InetAddress.getAllByName(name)) {
+                    nodes.add(new Node(a, Constants.DEFAULT_P2P_PORT));
+                }
+            } catch (UnknownHostException e) {
+                logger.info("Failed to get seed nodes from {}", name);
             }
-        } catch (UnknownHostException e) {
-            logger.info("Failed to get seed nodes from {}", network);
         }
 
         return nodes;

--- a/src/test/java/org/semux/net/NodeManagerTest.java
+++ b/src/test/java/org/semux/net/NodeManagerTest.java
@@ -50,15 +50,15 @@ public class NodeManagerTest {
     @Test
     public void testGetSeedNodes() {
         // Seed nodes for main net
-        Set<Node> peers = NodeManager.getSeedNodes(Network.MAINNET);
+        Set<Node> peers = new NodeManager(kernelRule1.getKernel()).getSeedNodes(Network.MAINNET);
         assertFalse(peers.isEmpty());
 
         // Seed nodes for test net
-        peers = NodeManager.getSeedNodes(Network.TESTNET);
+        peers = new NodeManager(kernelRule1.getKernel()).getSeedNodes(Network.TESTNET);
         assertFalse(peers.isEmpty());
 
         // Seed nodes for dev net
-        peers = NodeManager.getSeedNodes(Network.DEVNET);
+        peers = new NodeManager(kernelRule1.getKernel()).getSeedNodes(Network.DEVNET);
         assertTrue(peers.isEmpty());
     }
 


### PR DESCRIPTION
For network reliability, we support more than just a primary
DNS seed.  At least, we're ready to add more easily as they're
available.

fixes #624