### PR TITLE
GUI: Validate address alias length

### DIFF
--- a/src/main/java/org/semux/gui/dialog/AddressBookUpdateDialog.java
+++ b/src/main/java/org/semux/gui/dialog/AddressBookUpdateDialog.java
@@ -34,6 +34,7 @@ import org.semux.util.exception.UnreachableException;
 public class AddressBookUpdateDialog extends JDialog implements ActionListener {
 
     private static final long serialVersionUID = 1L;
+    private static final int MAX_ADDRESS_NAME_LENGTH = 256;
 
     private transient Wallet wallet;
     private transient WalletModel model;
@@ -113,7 +114,7 @@ public class AddressBookUpdateDialog extends JDialog implements ActionListener {
             String name = nameText.getText().trim();
             String address = addressText.getText().trim();
 
-            if (StringUtils.isEmpty(name)) {
+            if (StringUtils.isEmpty(name) || name.length() > MAX_ADDRESS_NAME_LENGTH) {
                 JOptionPane.showMessageDialog(this, GuiMessages.get("InvalidName"));
                 return;
             }


### PR DESCRIPTION
Trivial, but let's prevent errant use by limiting max
length on address aliases.  Set to arbitrary 256 chars.
At that point, the name is longer than just raw address, 
and of limited value.

fixes #659 