### PR TITLE
Config, Net: add mainnet.semux.net as an alternative dns seed

### DIFF
--- a/config/semux.properties
+++ b/config/semux.properties
@@ -45,7 +45,7 @@ net.relayRedundancy = 16
 net.channelIdleTimeout = 120000
 
 # DNS Seed (comma delimited)
-net.dnsSeeds.mainNet = mainnet.semux.org
+net.dnsSeeds.mainNet = mainnet.semux.org,mainnet.semux.net
 net.dnsSeeds.testNet = testnet.semux.org
 
 #================

--- a/src/main/java/org/semux/config/AbstractConfig.java
+++ b/src/main/java/org/semux/config/AbstractConfig.java
@@ -75,7 +75,7 @@ public abstract class AbstractConfig implements Config {
             MessageCode.BFT_NEW_VIEW,
             MessageCode.BFT_PROPOSAL,
             MessageCode.BFT_VOTE));
-    protected List<String> netDnsSeedsMainNet = Collections.singletonList("mainnet.semux.org");
+    protected List<String> netDnsSeedsMainNet = Collections.unmodifiableList(Arrays.asList("mainnet.semux.org","mainnet.semux.net"));
     protected List<String> netDnsSeedsTestNet = Collections.singletonList("testnet.semux.org");
 
     // =========================


### PR DESCRIPTION
fix #624 

```
$ dig mainnet.semux.net @8.8.8.8

; <<>> DiG 9.9.5-9+deb8u12-Debian <<>> mainnet.semux.net @8.8.8.8
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 54467
;; flags: qr rd ra; QUERY: 1, ANSWER: 5, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 512
;; QUESTION SECTION:
;mainnet.semux.net.             IN      A

;; ANSWER SECTION:
mainnet.semux.net.      599     IN      A       23.102.239.10
mainnet.semux.net.      599     IN      A       35.198.39.94
mainnet.semux.net.      599     IN      A       35.201.187.136
mainnet.semux.net.      599     IN      A       35.226.132.132
mainnet.semux.net.      599     IN      A       51.143.156.145

;; Query time: 12 msec
;; SERVER: 8.8.8.8#53(8.8.8.8)
;; WHEN: Mon Feb 12 04:43:41 CST 2018
;; MSG SIZE  rcvd: 126

```