### PR TITLE
[WIP] DB: Store recent validator stats

### DIFF
--- a/src/main/java/org/semux/core/Blockchain.java
+++ b/src/main/java/org/semux/core/Blockchain.java
@@ -9,6 +9,7 @@ package org.semux.core;
 import java.util.List;
 
 import org.semux.core.BlockchainImpl.ValidatorStats;
+import org.semux.core.BlockchainImpl.RecentValidatorStats;
 import org.semux.core.state.AccountState;
 import org.semux.core.state.DelegateState;
 
@@ -179,6 +180,14 @@ public interface Blockchain {
      * @return
      */
     ValidatorStats getValidatorStats(byte[] address);
+
+    /**
+     * Returns the statistics of a validator.
+     *
+     * @param address
+     * @return
+     */
+    RecentValidatorStats getRecentValidatorStats(long currentBlockNumber, byte[] address);
 
     /**
      * Register a blockchain listener.

--- a/src/main/java/org/semux/util/SimpleDecoder.java
+++ b/src/main/java/org/semux/util/SimpleDecoder.java
@@ -7,6 +7,8 @@
 package org.semux.util;
 
 import java.io.UnsupportedEncodingException;
+import java.util.Set;
+import java.util.TreeSet;
 
 import org.semux.util.exception.SimpleCodecException;
 
@@ -127,5 +129,21 @@ public class SimpleDecoder {
      */
     protected long unsignedInt(int i) {
         return i & 0x00000000ffffffffL;
+    }
+
+    /**
+     * Reads a Set of Longs
+     */
+    public Set<Long> readLongSet(boolean vlq) {
+        int len = vlq ? readSize() : readInt();
+        // 8 bytes per value
+        len = len / 8;
+
+        require(len);
+        Set<Long> set = new TreeSet<>();
+        for (int i = 0; i < len; i++) {
+            set.add(readLong());
+        }
+        return set;
     }
 }

--- a/src/main/java/org/semux/util/SimpleEncoder.java
+++ b/src/main/java/org/semux/util/SimpleEncoder.java
@@ -8,6 +8,7 @@ package org.semux.util;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.util.Set;
 
 import org.semux.util.exception.SimpleCodecException;
 
@@ -112,6 +113,17 @@ public class SimpleEncoder {
             } else {
                 out.write((byte) buf[i++]);
             }
+        }
+    }
+
+    public void writeLongSet(Set<Long> set, boolean vlq) {
+        if (vlq) {
+            writeSize(set.size() * 8);
+        } else {
+            writeInt(set.size() * 8);
+        }
+        for (Long val : set) {
+            writeLong(val);
         }
     }
 }

--- a/src/test/java/org/semux/core/BlockchainImplTest.java
+++ b/src/test/java/org/semux/core/BlockchainImplTest.java
@@ -258,23 +258,41 @@ public class BlockchainImplTest {
     }
 
     @Test
-    public void testValidatorStates() {
+    public void testValidatorStats() {
         byte[] address = Bytes.random(20);
 
         assertEquals(0, chain.getValidatorStats(address).getBlocksForged());
         assertEquals(0, chain.getValidatorStats(address).getTurnsHit());
         assertEquals(0, chain.getValidatorStats(address).getTurnsMissed());
 
-        chain.adjustValidatorStats(address, StatsType.FORGED, 1);
+        chain.adjustValidatorStats(1l, address, StatsType.FORGED, 1);
         assertEquals(1, chain.getValidatorStats(address).getBlocksForged());
 
-        chain.adjustValidatorStats(address, StatsType.HIT, 1);
+        chain.adjustValidatorStats(1l, address, StatsType.HIT, 1);
         assertEquals(1, chain.getValidatorStats(address).getTurnsHit());
 
-        chain.adjustValidatorStats(address, StatsType.MISSED, 1);
+        chain.adjustValidatorStats(1l, address, StatsType.MISSED, 1);
         assertEquals(1, chain.getValidatorStats(address).getTurnsMissed());
-        chain.adjustValidatorStats(address, StatsType.MISSED, 1);
+        chain.adjustValidatorStats(1l, address, StatsType.MISSED, 1);
         assertEquals(2, chain.getValidatorStats(address).getTurnsMissed());
+    }
+
+    @Test
+    public void testRecentValidatorStats() {
+        byte[] address = Bytes.random(20);
+        assertEquals(0, chain.getValidatorStats(address).getBlocksForged());
+
+        Long interval = 10l;
+        for (int i = 0; i < 10; i++) {
+            chain.adjustValidatorStats(i * interval, address, StatsType.FORGED, 1);
+            chain.adjustValidatorStats(i * interval + 1, address, StatsType.MISSED, 1);
+            chain.adjustValidatorStats(i * interval + 2, address, StatsType.MISSED, 1);
+            chain.adjustValidatorStats(i * interval + 3, address, StatsType.HIT, 1);
+        }
+        Long blockNum = 100l;
+        assertEquals(5, chain.getRecentValidatorStats(blockNum, address).getRecentBlocksForged(blockNum, 50l));
+        assertEquals(10, chain.getRecentValidatorStats(blockNum, address).getRecentTurnsMissed(blockNum, 50l));
+        assertEquals(5, chain.getRecentValidatorStats(blockNum, address).getRecentTurnsHit(blockNum, 50l));
     }
 
     private Block createBlock(long number) {

--- a/src/test/java/org/semux/util/SimpleDecoderTest.java
+++ b/src/test/java/org/semux/util/SimpleDecoderTest.java
@@ -8,6 +8,10 @@ package org.semux.util;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Set;
+import java.util.TreeSet;
 
 import org.junit.Test;
 import org.semux.crypto.Hex;
@@ -61,6 +65,46 @@ public class SimpleDecoderTest {
         assertEquals(long2, dec.readLong());
         assertArrayEquals(bytes2, dec.readBytes());
         assertEquals(string2, dec.readString());
+    }
+
+    @Test
+    public void testSetEncodingVlq() {
+
+        Set<Long> set = new TreeSet<>();
+        set.add(1l);
+        set.add(123141515234234l);
+        long l = 123l;
+        String s = "hello";
+        SimpleEncoder enc = new SimpleEncoder();
+        // enc.writeLong(l);
+        enc.writeLongSet(set, true);
+        // enc.writeString(s);
+
+        SimpleDecoder dec = new SimpleDecoder(enc.toBytes());
+
+        // assertEquals(l, dec.readLong());
+        assertTrue(set.equals(dec.readLongSet(true)));
+        // assertEquals(s, dec.readString());
+    }
+
+    @Test
+    public void testSetEncoding() {
+
+        Set<Long> set = new TreeSet<>();
+        set.add(1l);
+        set.add(123141515234234l);
+        long l = 123l;
+        String s = "hello";
+        SimpleEncoder enc = new SimpleEncoder();
+        enc.writeLong(l);
+        enc.writeLongSet(set, false);
+        enc.writeString(s);
+
+        SimpleDecoder dec = new SimpleDecoder(enc.toBytes());
+
+        assertEquals(l, dec.readLong());
+        assertTrue(set.equals(dec.readLongSet(false)));
+        assertEquals(s, dec.readString());
     }
 
     @Test


### PR DESCRIPTION
Store the set of recent stats by block, so we can calculate
stats over a time range.

Currently this is defaulted to display last 7 days
in delegates panel.  But we can make this configurable

There's a lot of future work here how we present this
information.  Likely a new API method or parameter.

At 30 days, this should add ~2MB to the database
8 bytes * # blocks in 30 days * 3 stats possible

--
This is a work in progress to get feedback on methodology
in case there's a better way to get rolling stats, or some 
problem I'm not seeing.   Please pardon some cleanup necessary
with scrutinizer, etc while we figure out if this is otherwise agreeable  :D

Currently it does not backfill stats, but that can be added
once we figure out a methodology that works for folks.

So if you start with a current sync'd install, it will only show
stats from now going forward.  If you want to see it operate, 
can start a sync from scratch.

This has possible use for #98 as an easy entry point to get recent stats.
