### PR TITLE
Upgrade Leveldb From 1.8 to 1.18

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,5 +49,6 @@ cache:
     - $HOME/.m2
     - $HOME/Library/Caches/Homebrew
 before_install:
+  - rm ~/.m2/settings.xml # remove the default settings.xml in order to use custom repos
   - if [ "$TRAVIS_OS_NAME" == "linux" ]; then source .travis/linux_start_xvfb.sh; fi
   - if [ "$TRAVIS_OS_NAME" == "osx" ]; then .travis/macos_install_jdk8.sh; fi

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ More info can be found at our [Wiki page](https://github.com/semuxproject/semux/
 ## Get started
 
 1. Download and install [Java SE Runtime Environment 9](http://www.oracle.com/technetwork/java/javase/downloads/jre9-downloads-3848532.html)
-2. *(Windows user) Download and install [Microsoft Visual C++ 2010 Redistributable Package](https://www.microsoft.com/en-us/download/details.aspx?id=14632)*
+2. *(Windows user) Download and install [Microsoft Visual C++ Redistributable for Visual Studio 2012 Update 4](https://www.microsoft.com/en-us/download/details.aspx?id=30679
+)*
 3. Download the [Latest Release](https://github.com/semuxproject/semux/releases) and unpack it to a desired directory.
 4. Run ``semux.exe`` if you're on Windows; run ``./semux-gui.sh`` or ``./semux-cli.sh`` if you're on Linux or macOS.
 

--- a/pom.xml
+++ b/pom.xml
@@ -500,7 +500,7 @@
                                         <urn>org.easytesting:fest-reflect:1.4.1:jar:null:test:2b92d5275e92a49e16c7ce6bd7e46b9080db0530</urn>
                                         <urn>org.easytesting:fest-util:1.2.5:jar:null:test:c4a8d7305b23b8d043be12c979813b096df11f44</urn>
                                         <urn>org.eluder.coveralls:coveralls-maven-plugin:4.3.0:maven-plugin:null:runtime:2f9f6bdef5dd1d863730a134a8f1280337440c46</urn>
-                                        <urn>org.fusesource.leveldbjni:leveldbjni-all:1.8:jar:null:compile:707350a2eeb1fa2ed77a32ddb3893ed308e941db</urn>
+                                        <urn>org.ethereum:leveldbjni-all:1.18.3:jar:null:compile:189e46b64f39a5f4f6de2cbdf20f42061b10d961</urn>
                                         <urn>org.hamcrest:hamcrest-core:1.3:jar:null:test:42a25dc3219429f0e5d060061f71acb49bf010a0</urn>
                                         <urn>org.hamcrest:hamcrest-library:1.3:jar:null:test:4785a3c21320980282f9f33d0d1264a69040538f</urn>
                                         <urn>org.javassist:javassist:3.21.0-GA:jar:null:test:598244f595db5c5fb713731eddbb1c91a58d959b</urn>

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,28 @@
         <url>https://github.com/semuxproject/semux/issues</url>
     </issueManagement>
 
+    <repositories>
+        <repository>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>central</id>
+            <name>bintray</name>
+            <url>https://jcenter.bintray.com</url>
+        </repository>
+    </repositories>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>central</id>
+            <name>bintray-plugins</name>
+            <url>https://jcenter.bintray.com</url>
+        </pluginRepository>
+    </pluginRepositories>
+
     <build>
         <plugins>
             <!-- compile -->
@@ -566,9 +588,9 @@
 
         <!-- LevelDB -->
         <dependency>
-            <groupId>org.fusesource.leveldbjni</groupId>
+            <groupId>org.ethereum</groupId>
             <artifactId>leveldbjni-all</artifactId>
-            <version>1.8</version>
+            <version>1.18.3</version>
         </dependency>
 
         <!-- Netty network framework -->

--- a/src/main/java/org/semux/Launcher.java
+++ b/src/main/java/org/semux/Launcher.java
@@ -226,7 +226,8 @@ public abstract class Launcher {
         switch (SystemUtil.getOsName()) {
         case WINDOWS:
             if (!SystemUtil.isWindowsVCRedist2010Installed()) {
-                throw new LauncherException("Microsoft Visual C++ 2010 Redistributable Package is not installed.");
+                throw new LauncherException(
+                        "Microsoft Visual C++ 2012 Redistributable Package is not installed. Please visit: https://www.microsoft.com/en-us/download/details.aspx?id=30679");
             }
             break;
         default:

--- a/src/main/java/org/semux/util/SystemUtil.java
+++ b/src/main/java/org/semux/util/SystemUtil.java
@@ -329,13 +329,13 @@ public class SystemUtil {
                 return Advapi32Util.registryGetIntValue(
                         Advapi32Util.registryGetKey(
                                 WinReg.HKEY_LOCAL_MACHINE,
-                                "SOFTWARE\\Microsoft\\VisualStudio\\10.0\\VC\\VCRedist\\x64",
+                                "SOFTWARE\\Microsoft\\VisualStudio\\11.0\\VC\\Runtimes\\x64",
                                 WinNT.KEY_READ | WinNT.KEY_WOW64_32KEY).getValue(),
                         "Installed") == 1;
             } else {
                 return Advapi32Util.registryGetIntValue(
                         WinReg.HKEY_LOCAL_MACHINE,
-                        "SOFTWARE\\Microsoft\\VisualStudio\\10.0\\VC\\VCRedist\\x86",
+                        "SOFTWARE\\Microsoft\\VisualStudio\\11.0\\VC\\Runtimes\\x86",
                         "Installed") == 1;
             }
         } catch (Win32Exception e) {


### PR DESCRIPTION
To fix #649 

Ethereumj appears to have resolved the issue of `Could not create random access file` by upgrading leveldb to 1.18: https://github.com/ethereum/ethereumj/issues/344#issuecomment-185990688

This upgrade is backward-compatible with v1.0.0 databases and tested on Windows 7 32bit with JDK8.

[VC++ 2012 Redist package](https://www.microsoft.com/en-us/download/details.aspx?id=30679) must be installed in place of VC++ 2010 Redist package.