### PR TITLE
Consensus: Improve voting speed

### DIFF
--- a/src/main/java/org/semux/consensus/SemuxBft.java
+++ b/src/main/java/org/semux/consensus/SemuxBft.java
@@ -827,18 +827,14 @@ public class SemuxBft implements Consensus {
     private Set<Transaction> getUnvalidatedTransactions(List<Transaction> transactions) {
         Set<Transaction> unvalidatedTransactions = new HashSet<>(transactions);
 
-        int previouslyValidatedCount = 0;
-        List<PendingManager.PendingTransaction> pending = pendingMgr.getPendingTransactions(-1);
-        for (PendingManager.PendingTransaction t : pending) {
-            if (t.transactionResult.isSuccess()) {
-                boolean found = unvalidatedTransactions.remove(t.transaction);
-                if (found) {
-                    previouslyValidatedCount++;
-                }
+        List<PendingManager.PendingTransaction> pendingTransactions = pendingMgr.getPendingTransactions(-1);
+        for (PendingManager.PendingTransaction pendingTransaction : pendingTransactions) {
+            if (pendingTransaction.transactionResult.isSuccess()) {
+                unvalidatedTransactions.remove(pendingTransaction.transaction);
             }
         }
-        logger.debug("Block validation: # txs = {}, previously validated = {} ms", transactions.size(),
-                previouslyValidatedCount);
+        logger.debug("Block validation: # txs = {}, # txs unvalidated = {} ms", transactions.size(),
+                unvalidatedTransactions.size());
 
         return unvalidatedTransactions;
     }

--- a/src/main/java/org/semux/consensus/SemuxBft.java
+++ b/src/main/java/org/semux/consensus/SemuxBft.java
@@ -7,10 +7,8 @@
 package org.semux.consensus;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.Set;

--- a/src/main/java/org/semux/consensus/SemuxBft.java
+++ b/src/main/java/org/semux/consensus/SemuxBft.java
@@ -823,7 +823,7 @@ public class SemuxBft implements Consensus {
      * @param transactions
      * @return
      */
-    private List<Transaction> getUnvalidatedTransactions(List<Transaction> transactions) {
+    protected List<Transaction> getUnvalidatedTransactions(List<Transaction> transactions) {
 
         Set<Transaction> pendingValidatedTransactions = pendingMgr.getPendingTransactions(-1)
                 .stream()
@@ -836,7 +836,7 @@ public class SemuxBft implements Consensus {
                 .filter(it -> !pendingValidatedTransactions.contains(it))
                 .collect(Collectors.toList());
 
-        logger.debug("Block validation: # txs = {}, # txs unvalidated = {} ms", transactions.size(),
+        logger.debug("Block validation: # txs = {}, # txs unvalidated = {}", transactions.size(),
                 unvalidatedTransactions.size());
 
         return unvalidatedTransactions;

--- a/src/main/java/org/semux/consensus/SemuxBft.java
+++ b/src/main/java/org/semux/consensus/SemuxBft.java
@@ -832,10 +832,9 @@ public class SemuxBft implements Consensus {
                 .map(pendingTx -> pendingTx.transaction)
                 .collect(Collectors.toSet());
 
-        Predicate<Transaction> containsPredicate = pendingValidatedTransactions::contains;
         List<Transaction> unvalidatedTransactions = transactions
                 .stream()
-                .filter(containsPredicate.negate())
+                .filter(it -> !pendingValidatedTransactions.contains(it))
                 .collect(Collectors.toList());
 
         logger.debug("Block validation: # txs = {}, # txs unvalidated = {} ms", transactions.size(),

--- a/src/main/java/org/semux/consensus/SemuxBft.java
+++ b/src/main/java/org/semux/consensus/SemuxBft.java
@@ -14,7 +14,6 @@ import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.locks.ReentrantReadWriteLock.WriteLock;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import org.semux.Kernel;

--- a/src/main/java/org/semux/core/Block.java
+++ b/src/main/java/org/semux/core/Block.java
@@ -8,6 +8,7 @@ package org.semux.core;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 
 import org.apache.commons.lang3.tuple.Pair;
@@ -136,8 +137,23 @@ public class Block {
      * @return
      */
     public static boolean validateTransactions(BlockHeader header, List<Transaction> transactions, Network network) {
+        return validateTransactions(header, transactions, transactions, network);
+    }
+
+    /**
+     * Validates transactions in parallel, only doing those that have not already
+     * been calculated.
+     *
+     * @param header
+     * @param unvalidatedTransactions
+     * @param transactions
+     * @param network
+     * @return
+     */
+    public static boolean validateTransactions(BlockHeader header, Collection<Transaction> unvalidatedTransactions,
+            List<Transaction> transactions, Network network) {
         // validate transactions
-        boolean valid = transactions.parallelStream().allMatch((tx) -> tx.validate(network));
+        boolean valid = unvalidatedTransactions.parallelStream().allMatch((tx) -> tx.validate(network));
         if (!valid) {
             return false;
         }
@@ -427,4 +443,5 @@ public class Block {
         return "Block [number = " + getNumber() + ", view = " + getView() + ", hash = " + Hex.encode(getHash())
                 + ", # txs = " + transactions.size() + ", # votes = " + votes.size() + "]";
     }
+
 }

--- a/src/main/java/org/semux/core/Block.java
+++ b/src/main/java/org/semux/core/Block.java
@@ -145,13 +145,17 @@ public class Block {
      * been calculated.
      *
      * @param header
+     *            block header
      * @param unvalidatedTransactions
-     * @param transactions
+     *            transactions needing validating
+     * @param allTransactions
+     *            all transactions within the block
      * @param network
+     *            network
      * @return
      */
     public static boolean validateTransactions(BlockHeader header, Collection<Transaction> unvalidatedTransactions,
-            List<Transaction> transactions, Network network) {
+            List<Transaction> allTransactions, Network network) {
         // validate transactions
         boolean valid = unvalidatedTransactions.parallelStream().allMatch((tx) -> tx.validate(network));
         if (!valid) {
@@ -159,7 +163,7 @@ public class Block {
         }
 
         // validate transactions root
-        byte[] root = MerkleUtil.computeTransactionsRoot(transactions);
+        byte[] root = MerkleUtil.computeTransactionsRoot(allTransactions);
         return Arrays.equals(root, header.getTransactionsRoot());
     }
 

--- a/src/main/java/org/semux/core/Transaction.java
+++ b/src/main/java/org/semux/core/Transaction.java
@@ -8,6 +8,8 @@ package org.semux.core;
 
 import java.util.Arrays;
 
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.semux.Network;
 import org.semux.config.Constants;
 import org.semux.crypto.Hash;
@@ -288,5 +290,31 @@ public class Transaction {
         return "Transaction [type=" + type + ", from=" + Hex.encode(getFrom()) + ", to=" + Hex.encode(to) + ", value="
                 + value + ", fee=" + fee + ", nonce=" + nonce + ", timestamp=" + timestamp + ", data="
                 + Hex.encode(data) + ", hash=" + Hex.encode(hash) + "]";
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+
+        if (o == null || getClass() != o.getClass())
+            return false;
+
+        Transaction that = (Transaction) o;
+
+        return new EqualsBuilder()
+                .append(encoded, that.encoded)
+                .append(hash, that.hash)
+                .append(signature, that.signature)
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(17, 37)
+                .append(encoded)
+                .append(hash)
+                .append(signature)
+                .toHashCode();
     }
 }

--- a/src/main/java/org/semux/crypto/Key.java
+++ b/src/main/java/org/semux/crypto/Key.java
@@ -15,6 +15,8 @@ import java.security.spec.InvalidKeySpecException;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.util.Arrays;
 
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.semux.crypto.cache.PublicKeyCache;
 import org.semux.util.Bytes;
 import org.semux.util.SystemUtil;
@@ -294,6 +296,30 @@ public class Key {
             byte[] a = Arrays.copyOfRange(bytes, LENGTH - A_LEN, LENGTH);
 
             return new Signature(s, a);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o)
+                return true;
+
+            if (o == null || getClass() != o.getClass())
+                return false;
+
+            Signature signature = (Signature) o;
+
+            return new EqualsBuilder()
+                    .append(s, signature.s)
+                    .append(a, signature.a)
+                    .isEquals();
+        }
+
+        @Override
+        public int hashCode() {
+            return new HashCodeBuilder(17, 37)
+                    .append(s)
+                    .append(a)
+                    .toHashCode();
         }
     }
 

--- a/src/test/java/org/semux/consensus/SemuxBftTest.java
+++ b/src/test/java/org/semux/consensus/SemuxBftTest.java
@@ -127,7 +127,6 @@ public class SemuxBftTest {
 
     @Test
     public void testFilterPendingTransactions() {
-        // mock blockchain with a single transaction
         Key to = new Key();
         Key from1 = new Key();
         long time = System.currentTimeMillis();

--- a/src/test/java/org/semux/consensus/SemuxBftTest.java
+++ b/src/test/java/org/semux/consensus/SemuxBftTest.java
@@ -141,7 +141,7 @@ public class SemuxBftTest {
         assertFalse(semuxBFT.getUnvalidatedTransactions(Collections.singletonList(tx2)).isEmpty());
     }
 
-    private Transaction createTransaction(Key to, Key from1, long time, long nonce) {
+    private Transaction createTransaction(Key to, Key from, long time, long nonce) {
         return new Transaction(
                 kernelRule.getKernel().getConfig().network(),
                 TransactionType.TRANSFER,
@@ -150,6 +150,6 @@ public class SemuxBftTest {
                 kernelRule.getKernel().getConfig().minTransactionFee(),
                 nonce,
                 time,
-                Bytes.EMPTY_BYTES).sign(from1);
+                Bytes.EMPTY_BYTES).sign(from);
     }
 }

--- a/src/test/java/org/semux/core/BlockTest.java
+++ b/src/test/java/org/semux/core/BlockTest.java
@@ -118,4 +118,17 @@ public class BlockTest {
         assertTrue(Block.validateTransactions(previousHeader, transactions, Network.DEVNET));
         assertTrue(Block.validateResults(previousHeader, results));
     }
+
+    @Test
+    public void testValidateTransactionsSparse() {
+        BlockHeader previousHeader = new BlockHeader(number - 1, coinbase, prevHash, timestamp - 1, transactionsRoot,
+                resultsRoot, stateRoot, data);
+        BlockHeader header = new BlockHeader(number, coinbase, previousHeader.getHash(), timestamp, transactionsRoot,
+                resultsRoot, stateRoot, data);
+
+        assertTrue(Block.validateHeader(previousHeader, header));
+        assertTrue(Block.validateTransactions(previousHeader, Collections.singleton(transactions.get(0)), transactions,
+                Network.DEVNET));
+        assertTrue(Block.validateResults(previousHeader, results));
+    }
 }

--- a/src/test/java/org/semux/core/TransactionTest.java
+++ b/src/test/java/org/semux/core/TransactionTest.java
@@ -76,4 +76,15 @@ public class TransactionTest {
         assertEquals(timestamp, tx.getTimestamp());
         assertArrayEquals(data, tx.getData());
     }
+
+    @Test
+    public void testEquality() {
+        Transaction tx = new Transaction(network, type, to, value, fee, nonce, timestamp, Bytes.random(128))
+                .sign(key);
+        Transaction tx2 = new Transaction(network, type, to, value, fee, nonce, timestamp, tx.getData())
+                .sign(key);
+
+        assertEquals(tx, tx2);
+        assertEquals(tx.hashCode(), tx2.hashCode());
+    }
 }


### PR DESCRIPTION
Currently, each validator has a background thread
that takes in pending transactions and validates them.

When a block proposal comes in, the validator verifies each
transaction again.  As most validators will have most of the
pending transactions that the forger will have, optimize to
save double calculation.

This is noticed to improve block validation time by ~90%
On testnet validator for 5k transactions from around 2.2
seconds down to 20ms.

I'm not sure if with 100 validators if pending transactions
propagate fully, so the actual results may be less.