### PR TITLE
Net: shuffle the list of nodes returned from GET_NODES message in order to balance the load on nodes

### DIFF
--- a/src/main/java/org/semux/net/SemuxP2pHandler.java
+++ b/src/main/java/org/semux/net/SemuxP2pHandler.java
@@ -8,6 +8,10 @@ package org.semux.net;
 
 import static org.semux.net.msg.p2p.NodesMessage.MAX_NODES;
 
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
@@ -228,9 +232,10 @@ public class SemuxP2pHandler extends SimpleChannelInboundHandler<Message> {
             break;
         }
         case GET_NODES: {
-            NodesMessage nodesMsg = new NodesMessage(channelMgr.getActiveAddresses()
-                    .stream().limit(MAX_NODES).map(Node::new)
-                    .collect(Collectors.toList()));
+            List<InetSocketAddress> activeAddresses = new ArrayList<>(channelMgr.getActiveAddresses());
+            Collections.shuffle(activeAddresses); // shuffle the list to balance the load of nodes
+            NodesMessage nodesMsg = new NodesMessage(activeAddresses.stream()
+                    .limit(MAX_NODES).map(Node::new).collect(Collectors.toList()));
             msgQueue.sendMessage(nodesMsg);
             break;
         }

--- a/src/main/java/org/semux/net/SemuxP2pHandler.java
+++ b/src/main/java/org/semux/net/SemuxP2pHandler.java
@@ -233,7 +233,7 @@ public class SemuxP2pHandler extends SimpleChannelInboundHandler<Message> {
         }
         case GET_NODES: {
             List<InetSocketAddress> activeAddresses = new ArrayList<>(channelMgr.getActiveAddresses());
-            Collections.shuffle(activeAddresses); // shuffle the list to balance the load of nodes
+            Collections.shuffle(activeAddresses); // shuffle the list to balance the load on nodes
             NodesMessage nodesMsg = new NodesMessage(activeAddresses.stream()
                     .limit(MAX_NODES).map(Node::new).collect(Collectors.toList()));
             msgQueue.sendMessage(nodesMsg);


### PR DESCRIPTION
In current implementation the P2P server returns the first 256 connected nodes whenever it receives a GET_NODES message, that may lead to unbalanced load on nodes considering that Semux network relies on a fixed set of seeders.