### PR TITLE
Config: disallow default API username or password

### DIFF
--- a/src/main/java/org/semux/cli/SemuxCli.java
+++ b/src/main/java/org/semux/cli/SemuxCli.java
@@ -18,6 +18,7 @@ import org.semux.Kernel;
 import org.semux.Launcher;
 import org.semux.config.Config;
 import org.semux.config.Constants;
+import org.semux.config.exception.ConfigException;
 import org.semux.core.Wallet;
 import org.semux.core.exception.WalletLockedException;
 import org.semux.crypto.Hex;
@@ -44,10 +45,10 @@ public class SemuxCli extends Launcher {
             cli.setupLogger(args);
             // start
             cli.start(args);
+        } catch (LauncherException | ConfigException exception) {
+            logger.error(exception.getMessage());
         } catch (ParseException exception) {
             logger.error(CliMessages.get("ParsingFailed", exception.getMessage()));
-        } catch (LauncherException exception) {
-            logger.error(exception.getMessage());
         }
     }
 

--- a/src/main/java/org/semux/config/AbstractConfig.java
+++ b/src/main/java/org/semux/config/AbstractConfig.java
@@ -19,6 +19,7 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import org.semux.Network;
+import org.semux.config.exception.ConfigException;
 import org.semux.core.TransactionType;
 import org.semux.core.Unit;
 import org.semux.crypto.Hash;
@@ -124,6 +125,7 @@ public abstract class AbstractConfig implements Config {
         this.networkVersion = networkVersion;
 
         init();
+        validate();
     }
 
     @Override
@@ -491,6 +493,13 @@ public abstract class AbstractConfig implements Config {
             }
         } catch (Exception e) {
             logger.error("Failed to load config file: {}", f, e);
+        }
+    }
+
+    protected void validate() {
+        if (apiEnabled &&
+                (apiUsername.equals("YOUR_API_USERNAME") || apiPassword.equals("YOUR_API_PASSWORD"))) {
+            throw new ConfigException("Please change your API username/password from the default values.");
         }
     }
 }

--- a/src/main/java/org/semux/config/AbstractConfig.java
+++ b/src/main/java/org/semux/config/AbstractConfig.java
@@ -496,9 +496,9 @@ public abstract class AbstractConfig implements Config {
         }
     }
 
-    protected void validate() {
+    private void validate() {
         if (apiEnabled &&
-                (apiUsername.equals("YOUR_API_USERNAME") || apiPassword.equals("YOUR_API_PASSWORD"))) {
+                ("YOUR_API_USERNAME".equals(apiUsername) || "YOUR_API_PASSWORD".equals(apiPassword))) {
             throw new ConfigException("Please change your API username/password from the default values.");
         }
     }

--- a/src/main/java/org/semux/config/exception/ConfigException.java
+++ b/src/main/java/org/semux/config/exception/ConfigException.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2017-2018 The Semux Developers
+ *
+ * Distributed under the MIT software license, see the accompanying file
+ * LICENSE or https://opensource.org/licenses/mit-license.php
+ */
+package org.semux.config.exception;
+
+public class ConfigException extends RuntimeException {
+
+    public ConfigException() {
+    }
+
+    public ConfigException(String message) {
+        super(message);
+    }
+
+    public ConfigException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public ConfigException(Throwable cause) {
+        super(cause);
+    }
+
+    public ConfigException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}

--- a/src/main/java/org/semux/gui/SemuxGui.java
+++ b/src/main/java/org/semux/gui/SemuxGui.java
@@ -26,6 +26,7 @@ import org.apache.commons.cli.ParseException;
 import org.semux.Kernel;
 import org.semux.Launcher;
 import org.semux.config.Constants;
+import org.semux.config.exception.ConfigException;
 import org.semux.core.Block;
 import org.semux.core.Blockchain;
 import org.semux.core.Transaction;
@@ -84,7 +85,7 @@ public class SemuxGui extends Launcher {
             // start
             gui.start(args);
 
-        } catch (LauncherException e) {
+        } catch (LauncherException | ConfigException e) {
             JOptionPane.showMessageDialog(
                     null,
                     e.getMessage(),


### PR DESCRIPTION
Careless users may open their wallets to the public with default API username & password. This commit enforces users to change API username & password from default values before an API server can be started.