### PR TITLE
UI: Remove File|Exit

### DIFF
--- a/src/main/java/org/semux/gui/Action.java
+++ b/src/main/java/org/semux/gui/Action.java
@@ -53,8 +53,6 @@ public enum Action {
 
     CHANGE_PASSWORD,
 
-    EXIT,
-
     ABOUT,
 
     HELP,

--- a/src/main/java/org/semux/gui/MenuBar.java
+++ b/src/main/java/org/semux/gui/MenuBar.java
@@ -33,7 +33,6 @@ import org.semux.gui.dialog.ChangePasswordDialog;
 import org.semux.gui.dialog.ExportPrivateKeyDialog;
 import org.semux.gui.dialog.InputDialog;
 import org.semux.message.GuiMessages;
-import org.semux.util.SystemUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -108,9 +107,6 @@ public class MenuBar extends JMenuBar implements ActionListener {
         Action action = Action.valueOf(e.getActionCommand());
 
         switch (action) {
-        case EXIT:
-            SystemUtil.exitAsync(0);
-            break;
         case RECOVER_ACCOUNTS:
             recoverAccounts();
             break;

--- a/src/main/java/org/semux/gui/MenuBar.java
+++ b/src/main/java/org/semux/gui/MenuBar.java
@@ -50,16 +50,6 @@ public class MenuBar extends JMenuBar implements ActionListener {
         this.gui = gui;
         this.frame = frame;
 
-        JMenu menuFile = new JMenu(GuiMessages.get("File"));
-        this.add(menuFile);
-
-        JMenuItem itemExit = new JMenuItem(GuiMessages.get("Exit"));
-        itemExit.setName("itemExit");
-        itemExit.setMnemonic(KeyEvent.VK_X);
-        itemExit.setActionCommand(Action.EXIT.name());
-        itemExit.addActionListener(this);
-        menuFile.add(itemExit);
-
         JMenu menuWallet = new JMenu(GuiMessages.get("Wallet"));
         this.add(menuWallet);
 


### PR DESCRIPTION
In looking at other applications, File|Exit does not seem to match up.
there are other ways to shut down the application

This will keep our options cleaner.

fixes  #487