### PR TITLE
Wrapper: add '--add-opens=java.base/sun.net.dns=ALL-UNNAMED' to avoid reflection warning

### DIFF
--- a/src/main/java/org/semux/wrapper/Wrapper.java
+++ b/src/main/java/org/semux/wrapper/Wrapper.java
@@ -99,6 +99,9 @@ public class Wrapper {
         if (SystemUtil.isJavaPlatformModuleSystemAvailable()) {
             Collections.addAll(defaults,
                     ImmutablePair.of(
+                            Pattern.compile("^--add-opens=java\\.base/sun\\.net\\.dns="),
+                            () -> "--add-opens=java.base/sun.net.dns=ALL-UNNAMED"),
+                    ImmutablePair.of(
                             Pattern.compile("^--add-opens=java\\.base/java\\.lang\\.reflect="),
                             () -> "--add-opens=java.base/java.lang.reflect=ALL-UNNAMED"),
                     ImmutablePair.of(

--- a/src/test/java/org/semux/wrapper/WrapperTest.java
+++ b/src/test/java/org/semux/wrapper/WrapperTest.java
@@ -111,6 +111,7 @@ public class WrapperTest {
                                         "-Dlog4j2.garbagefreeThreadContextMap=true",
                                         "-Dlog4j2.shutdownHookEnabled=false",
                                         "-Dlog4j2.disableJmx=true",
+                                        "--add-opens=java.base/sun.net.dns=ALL-UNNAMED",
                                         "--add-opens=java.base/java.lang.reflect=ALL-UNNAMED",
                                         "--add-opens=java.base/java.nio=ALL-UNNAMED",
                                         "--add-opens=java.base/sun.nio.ch=ALL-UNNAMED",


### PR DESCRIPTION
I just realized #641 wasn't properly fixed due to a missing `--add-opens` package