### PR TITLE
GUI: use BigDecimal instead of double for correctness

### DIFF
--- a/src/main/java/org/semux/gui/SwingUtil.java
+++ b/src/main/java/org/semux/gui/SwingUtil.java
@@ -67,6 +67,7 @@ import com.google.zxing.qrcode.QRCodeWriter;
 import com.google.zxing.qrcode.decoder.ErrorCorrectionLevel;
 
 import io.netty.util.internal.StringUtil;
+import java.text.DecimalFormat;
 
 public class SwingUtil {
 
@@ -295,10 +296,11 @@ public class SwingUtil {
      * @return
      * @throws ParseException
      */
-    public static Number parseNumber(String str) throws ParseException {
-        NumberFormat format = NumberFormat.getInstance();
+    public static BigDecimal parseNumber(String str) throws ParseException {
+        DecimalFormat format = (DecimalFormat) DecimalFormat.getInstance();
+        format.setParseBigDecimal(true);
         ParsePosition position = new ParsePosition(0);
-        Number number = format.parse(str, position);
+        BigDecimal number = (BigDecimal) format.parse(str, position);
         if (position.getIndex() != str.length() || number == null) {
             throw new ParseException("Failed to parse number: " + str, position.getIndex());
         }
@@ -411,7 +413,7 @@ public class SwingUtil {
                 .findAny()
                 .orElse(Pair.of(str, Unit.valueOf(unit)));
 
-        return BigDecimal.valueOf(parseNumber(numberUnit.getKey()).doubleValue())
+        return parseNumber(numberUnit.getKey())
                 .multiply(BigDecimal.valueOf(numberUnit.getValue()))
                 .longValue();
     }
@@ -479,7 +481,7 @@ public class SwingUtil {
      */
     public static final Comparator<String> NUMBER_COMPARATOR = (o1, o2) -> {
         try {
-            return Double.compare(parseNumber(o1).doubleValue(), parseNumber(o2).doubleValue());
+            return parseNumber(o1).compareTo(parseNumber(o2));
         } catch (ParseException e) {
             throw new NumberFormatException("Invalid number strings: " + o1 + ", " + o2);
         }
@@ -492,7 +494,7 @@ public class SwingUtil {
      */
     public static final Comparator<String> VALUE_COMPARATOR = (o1, o2) -> {
         try {
-            return Double.compare(parseValue(o1), parseValue(o2));
+            return Long.compare(parseValue(o1), parseValue(o2));
         } catch (ParseException e) {
             throw new NumberFormatException("Invalid number strings: " + o1 + ", " + o2);
         }

--- a/src/test/java/org/semux/gui/SwingUtilTest.java
+++ b/src/test/java/org/semux/gui/SwingUtilTest.java
@@ -6,6 +6,7 @@
  */
 package org.semux.gui;
 
+import java.math.BigDecimal;
 import static org.junit.Assert.assertEquals;
 
 import java.text.ParseException;
@@ -40,14 +41,14 @@ public class SwingUtilTest {
 
     @Test
     public void testFormatNumber() {
-        double x = 12345678.1234;
+        BigDecimal x = new BigDecimal("12345678.1234");
         assertEquals("12,345,678", SwingUtil.formatNumber(x, 0));
         assertEquals("12,345,678.12", SwingUtil.formatNumber(x, 2));
     }
 
     @Test
     public void testParseNumber() throws ParseException {
-        assertEquals(12345678.12, SwingUtil.parseNumber("12,345,678.12").doubleValue(), 10e-9);
+        assertEquals(new BigDecimal("12345678.12"), SwingUtil.parseNumber("12,345,678.12"));
     }
 
     @Test


### PR DESCRIPTION
Today I was thinking about replacing `Unit` class with an enum and I think the `BigDecimal` is not as good as the dedicated class to represent a Semux Amount. That could be the next step. Once this one is merged, I will prepare new pull-request with `Unit` enum and dedicated class representing an amount.