### PR TITLE
Concensus: Testnet permits larger blocks

### DIFF
--- a/src/main/java/org/semux/config/TestnetConfig.java
+++ b/src/main/java/org/semux/config/TestnetConfig.java
@@ -15,6 +15,8 @@ public class TestnetConfig extends AbstractConfig {
 
     public TestnetConfig(String dataDir) {
         super(dataDir, Network.TESTNET, Constants.TESTNET_VERSION);
+        // testnet allows a much larger block size for performance tuning (100MB)
+        maxBlockTransactionsSize = 100 * 1024 * 1024;
     }
 
     @Override

--- a/src/main/java/org/semux/config/TestnetConfig.java
+++ b/src/main/java/org/semux/config/TestnetConfig.java
@@ -15,8 +15,8 @@ public class TestnetConfig extends AbstractConfig {
 
     public TestnetConfig(String dataDir) {
         super(dataDir, Network.TESTNET, Constants.TESTNET_VERSION);
-        // testnet allows a much larger block size for performance tuning (100MB)
-        maxBlockTransactionsSize = 100 * 1024 * 1024;
+        // testnet allows a much larger block size for performance tuning (10MB)
+        maxBlockTransactionsSize = 10 * 1024 * 1024;
     }
 
     @Override

--- a/src/main/java/org/semux/core/PendingManager.java
+++ b/src/main/java/org/semux/core/PendingManager.java
@@ -185,13 +185,13 @@ public class PendingManager implements Runnable, BlockchainListener {
     /**
      * Returns pending transactions and corresponding results.
      *
-     * @param limit
+     * @param byteLimit
      * @return
      */
-    public synchronized List<PendingTransaction> getPendingTransactions(int limit) {
+    public synchronized List<PendingTransaction> getPendingTransactions(int byteLimit) {
         List<PendingTransaction> txs = new ArrayList<>();
 
-        if (limit == -1) {
+        if (byteLimit == -1) {
             // returns all transactions if there is no limit
             txs.addAll(transactions);
         } else {
@@ -201,11 +201,11 @@ public class PendingManager implements Runnable, BlockchainListener {
             while (it.hasNext()) {
                 PendingTransaction tx = it.next();
 
-                if (size + tx.transaction.size() > limit) {
+                size += tx.transaction.size();
+                if (size > byteLimit) {
                     break;
                 } else {
                     txs.add(tx);
-                    size += tx.transaction.size();
                 }
             }
         }


### PR DESCRIPTION
For testing purposes and performance tuning
it is desirable to be able to test larger amounts
of transactions than would normally make sense
in order to identify bottlenecks for future growth 
and optimization.

Note: This will affect concensus during rollout, but as it is testnet
it seems fine if during rollout that larger blocks will
fail validation until we get 67%.  The backup validator will
propose the smaller block and not hang concensus.

If we decide to go with larger blocks in future, we'll
have to use @cryptokat 's method for signaling forks,
but this is just for test purposes, and not proposing larger
blocks overall at this time.

fixes #706 


Also trivial rename for clarity.