### PR TITLE
GUI: Add getBlockByNumber to console

### DIFF
--- a/src/main/java/org/semux/api/ConsoleApi.java
+++ b/src/main/java/org/semux/api/ConsoleApi.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2017-2018 The Semux Developers
+ *
+ * Distributed under the MIT software license, see the accompanying file
+ * LICENSE or https://opensource.org/licenses/mit-license.php
+ */
+package org.semux.api;
+
+import static org.semux.config.Constants.JSON_MIME;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import org.semux.api.response.GetBlockResponse;
+
+/**
+ * Additional console-only API
+ *
+ */
+public interface ConsoleApi {
+
+    @GET
+    @Path("get_block_by_number")
+    @ApiOperation(value = "Get block by block number", notes = "Returns a block.", response = GetBlockResponse.class)
+    @Produces(JSON_MIME)
+    ApiHandlerResponse getBlockByNumber(
+            @ApiParam(value = "Block number", required = true) @QueryParam("number") String blockNum);
+
+}

--- a/src/main/java/org/semux/api/ConsoleApiImpl.java
+++ b/src/main/java/org/semux/api/ConsoleApiImpl.java
@@ -34,7 +34,7 @@ public class ConsoleApiImpl implements ConsoleApi {
         Long number;
         try {
             number = Long.parseLong(blockNum);
-        } catch (CryptoException ex) {
+        } catch (NumberFormatException ex) {
             return failure("Parameter `number` is not a valid number");
         }
 

--- a/src/main/java/org/semux/api/ConsoleApiImpl.java
+++ b/src/main/java/org/semux/api/ConsoleApiImpl.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) 2017-2018 The Semux Developers
+ *
+ * Distributed under the MIT software license, see the accompanying file
+ * LICENSE or https://opensource.org/licenses/mit-license.php
+ */
+package org.semux.api;
+
+import org.semux.Kernel;
+import org.semux.api.response.GetBlockResponse;
+import org.semux.api.response.Types;
+import org.semux.core.Block;
+import org.semux.crypto.CryptoException;
+
+/**
+ */
+public class ConsoleApiImpl implements ConsoleApi {
+
+    private Kernel kernel;
+
+    public ConsoleApiImpl(Kernel kernel) {
+        this.kernel = kernel;
+    }
+
+    public ApiHandlerResponse failure(String message) {
+        return new ApiHandlerResponse(false, message);
+    }
+
+    @Override
+    public ApiHandlerResponse getBlockByNumber(String blockNum) {
+        if (blockNum == null) {
+            return failure("Parameter `number` is required");
+        }
+        Long number;
+        try {
+            number = Long.parseLong(blockNum);
+        } catch (CryptoException ex) {
+            return failure("Parameter `number` is not a valid number");
+        }
+
+        Block block = kernel.getBlockchain().getBlock(number);
+
+        if (block == null) {
+            return failure("The requested block was not found");
+        }
+
+        return new GetBlockResponse(true, new Types.BlockType(block));
+    }
+}

--- a/src/test/java/org/semux/gui/dialog/ConsoleDialogTest.java
+++ b/src/test/java/org/semux/gui/dialog/ConsoleDialogTest.java
@@ -7,6 +7,13 @@
 package org.semux.gui.dialog;
 
 import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 import org.assertj.swing.edt.GuiActionRunner;
 import org.assertj.swing.fixture.DialogFixture;
@@ -18,8 +25,14 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.semux.core.Block;
+import org.semux.core.BlockHeader;
+import org.semux.core.Blockchain;
+import org.semux.core.Transaction;
+import org.semux.core.TransactionResult;
 import org.semux.gui.model.WalletModel;
 import org.semux.rules.KernelRule;
+import org.semux.util.Bytes;
 
 /**
  */
@@ -51,7 +64,33 @@ public class ConsoleDialogTest extends AssertJSwingJUnitTestCase {
         console.textBox("txtInput").enterText("listAccounts\n");
         String walletAddress = kernelRule1.getKernel().getWallet().getAccount(0).toAddressString();
 
-        await().until(() -> consoleText.text().contains(walletAddress));
+        // getBlockByNumber
+        Blockchain blockChain = mock(Blockchain.class);
+        Block block = getBlock();
+        when(blockChain.getBlock(anyLong())).thenReturn(block);
+        kernelRule1.getKernel().setBlockchain(blockChain);
+
+        console.textBox("txtInput").enterText("getBlockByNumber 1\n");
+
+        await().until(() -> consoleText.text().contains("transactionsRoot"));
+    }
+
+    private Block getBlock() {
+
+        long number = 1;
+        byte[] coinbase = Bytes.random(20);
+        byte[] prevHash = Bytes.random(20);
+        long timestamp = System.currentTimeMillis();
+        byte[] transactionsRoot = Bytes.random(32);
+        byte[] resultsRoot = Bytes.random(32);
+        byte[] stateRoot = Bytes.random(32);
+        byte[] data = {};
+        List<Transaction> transactions = Collections.emptyList();
+        List<TransactionResult> results = Arrays.asList(new TransactionResult(true), new TransactionResult(true));
+        BlockHeader header = new BlockHeader(number, coinbase, prevHash, timestamp, transactionsRoot, resultsRoot,
+                stateRoot, data);
+        Block block = new Block(header, transactions, results);
+        return block;
     }
 
     @Override


### PR DESCRIPTION
Add support for console API that isn't in REST
API.  As the console only supports string parameters
we add a getBlockByNumber.

This allows for additional console methods in the
future as well.

fixes #699