### PR TITLE
Merge master into develop

### DIFF
--- a/src/main/java/org/semux/core/Wallet.java
+++ b/src/main/java/org/semux/core/Wallet.java
@@ -441,7 +441,7 @@ public class Wallet {
                 logger.error("Failed to create the directory for wallet");
                 return false;
             }
-            
+
             IOUtil.writeToFile(enc.toBytes(), file);
             return true;
         } catch (CryptoException e) {


### PR DESCRIPTION
#718 was mistakenly merged directly into `master` branch.

Maybe we should consider changing the default branch from `master` to `develop` to avoid this kind of mistake. See: https://help.github.com/articles/setting-the-default-branch/