### PR TITLE
Util: Improve UTF8 CharSet Expression and Revert Scanner Default Charset

### DIFF
--- a/findbugs-exclude.xml
+++ b/findbugs-exclude.xml
@@ -1,8 +1,2 @@
 <FindBugsFilter>
-    <!-- It's fine for console reads to rely on default encoding -->
-    <Match>
-        <Class name="org.semux.util.ConsoleUtil"/>
-        <Bug pattern="DM_DEFAULT_ENCODING"/>
-    </Match>
 </FindBugsFilter>
-

--- a/findbugs-exclude.xml
+++ b/findbugs-exclude.xml
@@ -1,0 +1,8 @@
+<FindBugsFilter>
+    <!-- It's fine for console reads to rely on default encoding -->
+    <Match>
+        <Class name="org.semux.util.ConsoleUtil"/>
+        <Bug pattern="DM_DEFAULT_ENCODING"/>
+    </Match>
+</FindBugsFilter>
+

--- a/pom.xml
+++ b/pom.xml
@@ -482,6 +482,8 @@
                                         <urn>com.github.oshi:oshi-core:3.4.4:jar:null:compile:f1aa8e053d26f49b909a845745018c57fe9d7a74</urn>
                                         <urn>com.github.stefanbirkner:system-rules:1.17.1:jar:null:test:3642fe208063ad538ec6a2fca141d13e15f2b1f2</urn>
                                         <urn>com.github.zafarkhaja:java-semver:0.9.0:jar:null:compile:59a83ca73c72a5e25b3f0b1bb305230a11000329</urn>
+                                        <urn>com.google.code.findbugs:annotations:3.0.1:jar:null:compile:fc019a2216218990d64dfe756e7aa20f0069dea2</urn>
+                                        <urn>com.google.code.findbugs:jsr305:3.0.1:jar:null:compile:f7be08ec23c21485b9b5a1cf1654c2ec8c58168d</urn>
                                         <urn>com.google.zxing:core:3.3.2:jar:null:compile:f47e3fc99fb2755b8a354d60efa021a0b88f4180</urn>
                                         <urn>com.mycila:license-maven-plugin:3.0:maven-plugin:null:runtime:6e6175f847574fd15c644a69b540e279ea5d173f</urn>
                                         <urn>commons-beanutils:commons-beanutils:1.9.2:jar:null:compile:7a87d845ad3a155297e8f67d9008f4c1e5656b71</urn>
@@ -766,6 +768,13 @@
             <groupId>com.github.ben-manes.caffeine</groupId>
             <artifactId>caffeine</artifactId>
             <version>2.6.1</version>
+        </dependency>
+
+        <!-- FindBugs annotations -->
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>annotations</artifactId>
+            <version>3.0.1</version>
         </dependency>
 
         <!-- Testing Libraries -->

--- a/pom.xml
+++ b/pom.xml
@@ -432,6 +432,7 @@
                     <!-- FIXME: lower the FindBugs threshold to Medium -->
                     <threshold>High</threshold>
                     <xmlOutput>true</xmlOutput>
+                    <excludeFilterFile>${project.basedir}/findbugs-exclude.xml</excludeFilterFile>
                 </configuration>
             </plugin>
 
@@ -482,8 +483,6 @@
                                         <urn>com.github.oshi:oshi-core:3.4.4:jar:null:compile:f1aa8e053d26f49b909a845745018c57fe9d7a74</urn>
                                         <urn>com.github.stefanbirkner:system-rules:1.17.1:jar:null:test:3642fe208063ad538ec6a2fca141d13e15f2b1f2</urn>
                                         <urn>com.github.zafarkhaja:java-semver:0.9.0:jar:null:compile:59a83ca73c72a5e25b3f0b1bb305230a11000329</urn>
-                                        <urn>com.google.code.findbugs:annotations:3.0.1:jar:null:compile:fc019a2216218990d64dfe756e7aa20f0069dea2</urn>
-                                        <urn>com.google.code.findbugs:jsr305:3.0.1:jar:null:compile:f7be08ec23c21485b9b5a1cf1654c2ec8c58168d</urn>
                                         <urn>com.google.zxing:core:3.3.2:jar:null:compile:f47e3fc99fb2755b8a354d60efa021a0b88f4180</urn>
                                         <urn>com.mycila:license-maven-plugin:3.0:maven-plugin:null:runtime:6e6175f847574fd15c644a69b540e279ea5d173f</urn>
                                         <urn>commons-beanutils:commons-beanutils:1.9.2:jar:null:compile:7a87d845ad3a155297e8f67d9008f4c1e5656b71</urn>
@@ -768,13 +767,6 @@
             <groupId>com.github.ben-manes.caffeine</groupId>
             <artifactId>caffeine</artifactId>
             <version>2.6.1</version>
-        </dependency>
-
-        <!-- FindBugs annotations -->
-        <dependency>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>annotations</artifactId>
-            <version>3.0.1</version>
         </dependency>
 
         <!-- Testing Libraries -->

--- a/src/main/java/org/semux/api/ConsoleApi.java
+++ b/src/main/java/org/semux/api/ConsoleApi.java
@@ -13,9 +13,10 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 
+import org.semux.api.response.GetBlockResponse;
+
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
-import org.semux.api.response.GetBlockResponse;
 
 /**
  * Additional console-only API

--- a/src/main/java/org/semux/api/ConsoleApiImpl.java
+++ b/src/main/java/org/semux/api/ConsoleApiImpl.java
@@ -10,7 +10,6 @@ import org.semux.Kernel;
 import org.semux.api.response.GetBlockResponse;
 import org.semux.api.response.Types;
 import org.semux.core.Block;
-import org.semux.crypto.CryptoException;
 
 /**
  */

--- a/src/main/java/org/semux/api/SemuxApiImpl.java
+++ b/src/main/java/org/semux/api/SemuxApiImpl.java
@@ -6,6 +6,8 @@
  */
 package org.semux.api;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import java.io.File;
 import java.net.UnknownHostException;
 import java.nio.charset.Charset;
@@ -59,7 +61,7 @@ import org.semux.net.filter.SemuxIpFilter;
 import net.i2p.crypto.eddsa.EdDSAPublicKey;
 
 public class SemuxApiImpl implements SemuxApi {
-    private static final Charset CHARSET = Charset.forName("UTF-8");
+    private static final Charset CHARSET = UTF_8;
 
     private Kernel kernel;
 

--- a/src/main/java/org/semux/cli/SemuxCli.java
+++ b/src/main/java/org/semux/cli/SemuxCli.java
@@ -26,6 +26,7 @@ import org.semux.crypto.Key;
 import org.semux.exception.LauncherException;
 import org.semux.message.CliMessages;
 import org.semux.net.filter.exception.IpFilterJsonParseException;
+import org.semux.util.ConsoleUtil;
 import org.semux.util.SystemUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -249,8 +250,8 @@ public class SemuxCli extends Launcher {
      * @return new password, or null if the confirmation failed
      */
     private String readNewPassword() {
-        String newPassword = SystemUtil.readPassword(CliMessages.get("EnterNewPassword"));
-        String newPasswordRe = SystemUtil.readPassword(CliMessages.get("ReEnterNewPassword"));
+        String newPassword = ConsoleUtil.readPassword(CliMessages.get("EnterNewPassword"));
+        String newPasswordRe = ConsoleUtil.readPassword(CliMessages.get("ReEnterNewPassword"));
 
         if (!newPassword.equals(newPasswordRe)) {
             logger.error(CliMessages.get("ReEnterNewPasswordIncorrect"));
@@ -309,7 +310,7 @@ public class SemuxCli extends Launcher {
 
     protected Wallet loadAndUnlockWallet() {
         if (getPassword() == null) {
-            setPassword(SystemUtil.readPassword());
+            setPassword(ConsoleUtil.readPassword());
         }
 
         Wallet wallet = loadWallet();

--- a/src/main/java/org/semux/gui/SwingUtil.java
+++ b/src/main/java/org/semux/gui/SwingUtil.java
@@ -23,6 +23,7 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.net.URL;
 import java.text.DateFormat;
+import java.text.DecimalFormat;
 import java.text.NumberFormat;
 import java.text.ParseException;
 import java.text.ParsePosition;
@@ -67,7 +68,6 @@ import com.google.zxing.qrcode.QRCodeWriter;
 import com.google.zxing.qrcode.decoder.ErrorCorrectionLevel;
 
 import io.netty.util.internal.StringUtil;
-import java.text.DecimalFormat;
 
 public class SwingUtil {
 

--- a/src/main/java/org/semux/util/ConsoleUtil.java
+++ b/src/main/java/org/semux/util/ConsoleUtil.java
@@ -9,9 +9,6 @@ package org.semux.util;
 import java.io.Console;
 import java.util.Scanner;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-
-@SuppressFBWarnings(value = "DM_DEFAULT_ENCODING", justification = "It's fine for console reads to rely on default encoding")
 public class ConsoleUtil {
 
     private static final Scanner scanner = new Scanner(System.in);

--- a/src/main/java/org/semux/util/ConsoleUtil.java
+++ b/src/main/java/org/semux/util/ConsoleUtil.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2017-2018 The Semux Developers
+ *
+ * Distributed under the MIT software license, see the accompanying file
+ * LICENSE or https://opensource.org/licenses/mit-license.php
+ */
+package org.semux.util;
+
+import java.io.Console;
+import java.util.Scanner;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+@SuppressFBWarnings(value = "DM_DEFAULT_ENCODING", justification = "It's fine for console reads to rely on default encoding")
+public class ConsoleUtil {
+
+    private static final Scanner scanner = new Scanner(System.in);
+
+    private ConsoleUtil() {
+    }
+
+    /**
+     * Reads a line from the console.
+     *
+     * @param prompt
+     * @return
+     */
+    public static String readLine(String prompt) {
+        if (prompt != null) {
+            System.out.print(prompt);
+            System.out.flush();
+        }
+
+        return scanner.nextLine();
+    }
+
+    /**
+     * Reads a password from the console.
+     *
+     * @param prompt
+     *            A message to display before reading password
+     * @return
+     */
+    public static String readPassword(String prompt) {
+        Console console = System.console();
+
+        if (console == null) {
+            if (prompt != null) {
+                System.out.print(prompt);
+                System.out.flush();
+            }
+
+            return scanner.nextLine();
+        }
+
+        return new String(console.readPassword(prompt));
+    }
+
+    /**
+     * Reads a password from the console.
+     *
+     * @return
+     */
+    public static String readPassword() {
+        return readPassword("Please enter your password: ");
+    }
+}

--- a/src/main/java/org/semux/util/ConsoleUtil.java
+++ b/src/main/java/org/semux/util/ConsoleUtil.java
@@ -7,11 +7,13 @@
 package org.semux.util;
 
 import java.io.Console;
+import java.io.InputStreamReader;
+import java.nio.charset.Charset;
 import java.util.Scanner;
 
 public class ConsoleUtil {
 
-    private static final Scanner scanner = new Scanner(System.in);
+    private static final Scanner scanner = new Scanner(new InputStreamReader(System.in, Charset.defaultCharset()));
 
     private ConsoleUtil() {
     }

--- a/src/main/java/org/semux/util/IOUtil.java
+++ b/src/main/java/org/semux/util/IOUtil.java
@@ -13,7 +13,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
-import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;

--- a/src/main/java/org/semux/util/SystemUtil.java
+++ b/src/main/java/org/semux/util/SystemUtil.java
@@ -6,17 +6,16 @@
  */
 package org.semux.util;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import java.io.BufferedReader;
-import java.io.Console;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.URL;
 import java.net.URLConnection;
-import java.nio.charset.Charset;
 import java.util.Locale;
-import java.util.Scanner;
 import java.util.concurrent.ExecutionException;
 
 import org.semux.config.Constants;
@@ -47,8 +46,6 @@ public class SystemUtil {
     }
 
     private static final Logger logger = LoggerFactory.getLogger(SystemUtil.class);
-
-    private static final Scanner scanner = new Scanner(new InputStreamReader(System.in, Charset.forName("UTF-8")));
 
     public enum OsName {
         WINDOWS("Windows"),
@@ -136,7 +133,7 @@ public class SystemUtil {
             con.setReadTimeout(Constants.DEFAULT_READ_TIMEOUT);
 
             BufferedReader reader = new BufferedReader(
-                    new InputStreamReader(con.getInputStream(), Charset.forName("UTF-8")));
+                    new InputStreamReader(con.getInputStream(), UTF_8));
             String ip = reader.readLine().trim();
             reader.close();
 
@@ -155,52 +152,6 @@ public class SystemUtil {
         } catch (Exception e) {
             return InetAddress.getLoopbackAddress().getHostAddress();
         }
-    }
-
-    /**
-     * Reads a line from the console.
-     * 
-     * @param prompt
-     * @return
-     */
-    public static String readLine(String prompt) {
-        if (prompt != null) {
-            System.out.print(prompt);
-            System.out.flush();
-        }
-
-        return scanner.nextLine();
-    }
-
-    /**
-     * Reads a password from the console.
-     *
-     * @param prompt
-     *            A message to display before reading password
-     * @return
-     */
-    public static String readPassword(String prompt) {
-        Console console = System.console();
-
-        if (console == null) {
-            if (prompt != null) {
-                System.out.print(prompt);
-                System.out.flush();
-            }
-
-            return scanner.nextLine();
-        }
-
-        return new String(console.readPassword(prompt));
-    }
-
-    /**
-     * Reads a password from the console.
-     *
-     * @return
-     */
-    public static String readPassword() {
-        return readPassword("Please enter your password: ");
     }
 
     /**

--- a/src/test/java/org/semux/bench/SemuxPerformance.java
+++ b/src/test/java/org/semux/bench/SemuxPerformance.java
@@ -18,7 +18,7 @@ import org.semux.config.DevnetConfig;
 import org.semux.core.Unit;
 import org.semux.util.ApiClient;
 import org.semux.util.Bytes;
-import org.semux.util.SystemUtil;
+import org.semux.util.ConsoleUtil;
 
 public class SemuxPerformance {
     private static InetSocketAddress server = new InetSocketAddress("127.0.0.1", 5171);
@@ -58,12 +58,12 @@ public class SemuxPerformance {
     }
 
     public static void main(String[] args) throws Exception {
-        address = SystemUtil.readPassword("Please enter your wallet address: ");
-        username = SystemUtil.readPassword("Please enter your API username: ");
-        password = SystemUtil.readPassword("Please enter your API password: ");
+        address = ConsoleUtil.readPassword("Please enter your wallet address: ");
+        username = ConsoleUtil.readPassword("Please enter your API username: ");
+        password = ConsoleUtil.readPassword("Please enter your API password: ");
 
         while (true) {
-            int n = Integer.parseInt(SystemUtil.readLine("# transactions to send: ").replaceAll("[^\\d]", ""));
+            int n = Integer.parseInt(ConsoleUtil.readLine("# transactions to send: ").replaceAll("[^\\d]", ""));
             if (n > 0) {
                 testTransfer(n);
             } else {

--- a/src/test/java/org/semux/cli/SemuxCliTest.java
+++ b/src/test/java/org/semux/cli/SemuxCliTest.java
@@ -64,7 +64,7 @@ import org.semux.util.SystemUtil.OsName;
 import net.i2p.crypto.eddsa.KeyPairGenerator;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({ SystemUtil.class, Kernel.class, SemuxCli.class })
+@PrepareForTest({ SystemUtil.class, ConsoleUtil.class, Kernel.class, SemuxCli.class })
 @PowerMockIgnore({ "jdk.internal.*", "javax.management.*" })
 public class SemuxCliTest {
 
@@ -152,7 +152,7 @@ public class SemuxCliTest {
         when(semuxCLI.loadWallet()).thenReturn(wallet);
 
         // mock SystemUtil
-        mockStatic(SystemUtil.class);
+        mockStatic(SystemUtil.class, ConsoleUtil.class);
         when(ConsoleUtil.readPassword(any())).thenReturn("password");
         when(SystemUtil.getOsName()).thenReturn(OsName.LINUX);
         when(SystemUtil.getOsArch()).thenReturn("amd64");
@@ -180,7 +180,7 @@ public class SemuxCliTest {
         when(semuxCLI.loadWallet()).thenReturn(wallet);
 
         // mock SystemUtil
-        mockStatic(SystemUtil.class);
+        mockStatic(SystemUtil.class, ConsoleUtil.class);
         when(ConsoleUtil.readPassword()).thenReturn("oldpassword");
         when(SystemUtil.getOsName()).thenReturn(OsName.LINUX);
         when(SystemUtil.getOsArch()).thenReturn("amd64");
@@ -210,7 +210,7 @@ public class SemuxCliTest {
         when(semuxCLI.loadWallet()).thenReturn(wallet);
 
         // mock SystemUtil
-        mockStatic(SystemUtil.class);
+        mockStatic(SystemUtil.class, ConsoleUtil.class);
         when(ConsoleUtil.readPassword()).thenReturn("oldpassword");
         when(SystemUtil.getOsName()).thenReturn(OsName.LINUX);
         when(SystemUtil.getOsArch()).thenReturn("amd64");
@@ -240,7 +240,7 @@ public class SemuxCliTest {
         when(semuxCLI.loadWallet()).thenReturn(wallet);
 
         // mock SystemUtil
-        mockStatic(SystemUtil.class);
+        mockStatic(SystemUtil.class, ConsoleUtil.class);
         when(ConsoleUtil.readPassword()).thenReturn("oldpassword");
         when(SystemUtil.getOsName()).thenReturn(OsName.LINUX);
         when(SystemUtil.getOsArch()).thenReturn("amd64");
@@ -275,7 +275,7 @@ public class SemuxCliTest {
         whenNew(Key.class).withAnyArguments().thenReturn(newAccount);
 
         // mock SystemUtil
-        mockStatic(SystemUtil.class);
+        mockStatic(SystemUtil.class, ConsoleUtil.class);
         when(ConsoleUtil.readPassword(any())).thenReturn("oldpassword");
         when(SystemUtil.getOsName()).thenReturn(OsName.LINUX);
         when(SystemUtil.getOsArch()).thenReturn("amd64");
@@ -310,7 +310,7 @@ public class SemuxCliTest {
         doReturn(null).when(semuxCLI).startKernel(any(), any(), any());
 
         // mock SystemUtil
-        mockStatic(SystemUtil.class);
+        mockStatic(SystemUtil.class, ConsoleUtil.class);
         when(ConsoleUtil.readPassword(any())).thenReturn("a password").thenReturn("b password");
 
         // execution
@@ -355,7 +355,7 @@ public class SemuxCliTest {
         whenNew(Key.class).withAnyArguments().thenReturn(newAccount);
 
         // mock SystemUtil
-        mockStatic(SystemUtil.class);
+        mockStatic(SystemUtil.class, ConsoleUtil.class);
         when(ConsoleUtil.readPassword()).thenReturn("oldpassword");
 
         // execution
@@ -388,7 +388,7 @@ public class SemuxCliTest {
         when(semuxCLI.loadWallet()).thenReturn(wallet);
 
         // mock SystemUtil
-        mockStatic(SystemUtil.class);
+        mockStatic(SystemUtil.class, ConsoleUtil.class);
         when(ConsoleUtil.readPassword()).thenReturn("oldpassword");
 
         // execution
@@ -413,7 +413,7 @@ public class SemuxCliTest {
         when(semuxCLI.loadWallet()).thenReturn(wallet);
 
         // mock SystemUtil
-        mockStatic(SystemUtil.class);
+        mockStatic(SystemUtil.class, ConsoleUtil.class);
         when(ConsoleUtil.readPassword()).thenReturn("oldpassword");
         Mockito.when(ConsoleUtil.readPassword(anyString())).thenReturn("newpassword");
 
@@ -436,7 +436,7 @@ public class SemuxCliTest {
         when(semuxCLI.loadWallet()).thenReturn(wallet);
 
         // mock SystemUtil
-        mockStatic(SystemUtil.class);
+        mockStatic(SystemUtil.class, ConsoleUtil.class);
         when(ConsoleUtil.readPassword()).thenReturn("oldpassword");
         Mockito.when(ConsoleUtil.readPassword(anyString())).thenReturn("newpassword").thenReturn("newpasswordconfirm");
 
@@ -464,7 +464,7 @@ public class SemuxCliTest {
         when(wallet.getAccount(addressBytes)).thenReturn(account);
 
         // mock SystemUtil
-        mockStatic(SystemUtil.class);
+        mockStatic(SystemUtil.class, ConsoleUtil.class);
         when(ConsoleUtil.readPassword()).thenReturn("oldpassword");
 
         // execution
@@ -492,7 +492,7 @@ public class SemuxCliTest {
         when(wallet.getAccount(addressBytes)).thenReturn(null);
 
         // mock SystemUtil
-        mockStatic(SystemUtil.class);
+        mockStatic(SystemUtil.class, ConsoleUtil.class);
         when(ConsoleUtil.readPassword()).thenReturn("oldpassword");
         doCallRealMethod().when(SystemUtil.class, "exit", any(Integer.class));
 
@@ -519,7 +519,7 @@ public class SemuxCliTest {
         when(wallet.addAccount(any(Key.class))).thenReturn(false);
 
         // mock SystemUtil
-        mockStatic(SystemUtil.class);
+        mockStatic(SystemUtil.class, ConsoleUtil.class);
         when(ConsoleUtil.readPassword()).thenReturn("oldpassword");
         doCallRealMethod().when(SystemUtil.class, "exit", any(Integer.class));
 
@@ -547,7 +547,7 @@ public class SemuxCliTest {
         when(wallet.flush()).thenReturn(false);
 
         // mock SystemUtil
-        mockStatic(SystemUtil.class);
+        mockStatic(SystemUtil.class, ConsoleUtil.class);
         when(ConsoleUtil.readPassword()).thenReturn("oldpassword");
         doCallRealMethod().when(SystemUtil.class, "exit", any(Integer.class));
 
@@ -573,7 +573,7 @@ public class SemuxCliTest {
         when(wallet.flush()).thenReturn(true);
 
         // mock SystemUtil
-        mockStatic(SystemUtil.class);
+        mockStatic(SystemUtil.class, ConsoleUtil.class);
         when(ConsoleUtil.readPassword()).thenReturn("oldpassword");
 
         // execution

--- a/src/test/java/org/semux/cli/SemuxCliTest.java
+++ b/src/test/java/org/semux/cli/SemuxCliTest.java
@@ -57,6 +57,7 @@ import org.semux.core.Wallet;
 import org.semux.crypto.Hex;
 import org.semux.crypto.Key;
 import org.semux.message.CliMessages;
+import org.semux.util.ConsoleUtil;
 import org.semux.util.SystemUtil;
 import org.semux.util.SystemUtil.OsName;
 
@@ -152,7 +153,7 @@ public class SemuxCliTest {
 
         // mock SystemUtil
         mockStatic(SystemUtil.class);
-        when(SystemUtil.readPassword(any())).thenReturn("password");
+        when(ConsoleUtil.readPassword(any())).thenReturn("password");
         when(SystemUtil.getOsName()).thenReturn(OsName.LINUX);
         when(SystemUtil.getOsArch()).thenReturn("amd64");
         doReturn(null).when(semuxCLI).startKernel(any(), any(), any());
@@ -180,10 +181,10 @@ public class SemuxCliTest {
 
         // mock SystemUtil
         mockStatic(SystemUtil.class);
-        when(SystemUtil.readPassword()).thenReturn("oldpassword");
+        when(ConsoleUtil.readPassword()).thenReturn("oldpassword");
         when(SystemUtil.getOsName()).thenReturn(OsName.LINUX);
         when(SystemUtil.getOsArch()).thenReturn("amd64");
-        when(SystemUtil.readPassword()).thenReturn("oldpassword");
+        when(ConsoleUtil.readPassword()).thenReturn("oldpassword");
         doReturn(null).when(semuxCLI).startKernel(any(), any(), any());
         semuxCLI.start();
 
@@ -210,10 +211,10 @@ public class SemuxCliTest {
 
         // mock SystemUtil
         mockStatic(SystemUtil.class);
-        when(SystemUtil.readPassword()).thenReturn("oldpassword");
+        when(ConsoleUtil.readPassword()).thenReturn("oldpassword");
         when(SystemUtil.getOsName()).thenReturn(OsName.LINUX);
         when(SystemUtil.getOsArch()).thenReturn("amd64");
-        when(SystemUtil.readPassword()).thenReturn("oldpassword");
+        when(ConsoleUtil.readPassword()).thenReturn("oldpassword");
         doReturn(null).when(semuxCLI).startKernel(any(), any(), any());
         semuxCLI.start(new String[] { "--network", "testnet" });
 
@@ -240,10 +241,10 @@ public class SemuxCliTest {
 
         // mock SystemUtil
         mockStatic(SystemUtil.class);
-        when(SystemUtil.readPassword()).thenReturn("oldpassword");
+        when(ConsoleUtil.readPassword()).thenReturn("oldpassword");
         when(SystemUtil.getOsName()).thenReturn(OsName.LINUX);
         when(SystemUtil.getOsArch()).thenReturn("amd64");
-        when(SystemUtil.readPassword()).thenReturn("oldpassword");
+        when(ConsoleUtil.readPassword()).thenReturn("oldpassword");
         doReturn(null).when(semuxCLI).startKernel(any(), any(), any());
         semuxCLI.start(new String[] { "--network", "devnet" });
 
@@ -275,7 +276,7 @@ public class SemuxCliTest {
 
         // mock SystemUtil
         mockStatic(SystemUtil.class);
-        when(SystemUtil.readPassword(any())).thenReturn("oldpassword");
+        when(ConsoleUtil.readPassword(any())).thenReturn("oldpassword");
         when(SystemUtil.getOsName()).thenReturn(OsName.LINUX);
         when(SystemUtil.getOsArch()).thenReturn("amd64");
 
@@ -310,7 +311,7 @@ public class SemuxCliTest {
 
         // mock SystemUtil
         mockStatic(SystemUtil.class);
-        when(SystemUtil.readPassword(any())).thenReturn("a password").thenReturn("b password");
+        when(ConsoleUtil.readPassword(any())).thenReturn("a password").thenReturn("b password");
 
         // execution
         semuxCLI.start();
@@ -355,7 +356,7 @@ public class SemuxCliTest {
 
         // mock SystemUtil
         mockStatic(SystemUtil.class);
-        when(SystemUtil.readPassword()).thenReturn("oldpassword");
+        when(ConsoleUtil.readPassword()).thenReturn("oldpassword");
 
         // execution
         semuxCLI.createAccount();
@@ -388,7 +389,7 @@ public class SemuxCliTest {
 
         // mock SystemUtil
         mockStatic(SystemUtil.class);
-        when(SystemUtil.readPassword()).thenReturn("oldpassword");
+        when(ConsoleUtil.readPassword()).thenReturn("oldpassword");
 
         // execution
         semuxCLI.listAccounts();
@@ -413,8 +414,8 @@ public class SemuxCliTest {
 
         // mock SystemUtil
         mockStatic(SystemUtil.class);
-        when(SystemUtil.readPassword()).thenReturn("oldpassword");
-        Mockito.when(SystemUtil.readPassword(anyString())).thenReturn("newpassword");
+        when(ConsoleUtil.readPassword()).thenReturn("oldpassword");
+        Mockito.when(ConsoleUtil.readPassword(anyString())).thenReturn("newpassword");
 
         // execution
         semuxCLI.changePassword();
@@ -436,8 +437,8 @@ public class SemuxCliTest {
 
         // mock SystemUtil
         mockStatic(SystemUtil.class);
-        when(SystemUtil.readPassword()).thenReturn("oldpassword");
-        Mockito.when(SystemUtil.readPassword(anyString())).thenReturn("newpassword").thenReturn("newpasswordconfirm");
+        when(ConsoleUtil.readPassword()).thenReturn("oldpassword");
+        Mockito.when(ConsoleUtil.readPassword(anyString())).thenReturn("newpassword").thenReturn("newpasswordconfirm");
 
         // execution
         semuxCLI.changePassword();
@@ -464,7 +465,7 @@ public class SemuxCliTest {
 
         // mock SystemUtil
         mockStatic(SystemUtil.class);
-        when(SystemUtil.readPassword()).thenReturn("oldpassword");
+        when(ConsoleUtil.readPassword()).thenReturn("oldpassword");
 
         // execution
         semuxCLI.dumpPrivateKey(address);
@@ -492,7 +493,7 @@ public class SemuxCliTest {
 
         // mock SystemUtil
         mockStatic(SystemUtil.class);
-        when(SystemUtil.readPassword()).thenReturn("oldpassword");
+        when(ConsoleUtil.readPassword()).thenReturn("oldpassword");
         doCallRealMethod().when(SystemUtil.class, "exit", any(Integer.class));
 
         // expect System.exit(1)
@@ -519,7 +520,7 @@ public class SemuxCliTest {
 
         // mock SystemUtil
         mockStatic(SystemUtil.class);
-        when(SystemUtil.readPassword()).thenReturn("oldpassword");
+        when(ConsoleUtil.readPassword()).thenReturn("oldpassword");
         doCallRealMethod().when(SystemUtil.class, "exit", any(Integer.class));
 
         // expectation
@@ -547,7 +548,7 @@ public class SemuxCliTest {
 
         // mock SystemUtil
         mockStatic(SystemUtil.class);
-        when(SystemUtil.readPassword()).thenReturn("oldpassword");
+        when(ConsoleUtil.readPassword()).thenReturn("oldpassword");
         doCallRealMethod().when(SystemUtil.class, "exit", any(Integer.class));
 
         // expectation
@@ -573,7 +574,7 @@ public class SemuxCliTest {
 
         // mock SystemUtil
         mockStatic(SystemUtil.class);
-        when(SystemUtil.readPassword()).thenReturn("oldpassword");
+        when(ConsoleUtil.readPassword()).thenReturn("oldpassword");
 
         // execution
         semuxCLI.importPrivateKey(key);

--- a/src/test/java/org/semux/gui/SwingUtilTest.java
+++ b/src/test/java/org/semux/gui/SwingUtilTest.java
@@ -6,9 +6,9 @@
  */
 package org.semux.gui;
 
-import java.math.BigDecimal;
 import static org.junit.Assert.assertEquals;
 
+import java.math.BigDecimal;
 import java.text.ParseException;
 import java.util.Locale;
 

--- a/src/test/java/org/semux/util/IOUtilTest.java
+++ b/src/test/java/org/semux/util/IOUtilTest.java
@@ -6,6 +6,7 @@
  */
 package org.semux.util;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
@@ -22,7 +23,7 @@ import org.junit.Test;
 
 public class IOUtilTest {
 
-    private static final Charset CHARSET = Charset.forName("UTF-8");
+    private static final Charset CHARSET = UTF_8;
 
     private File f1 = new File("test1");
     private File f2 = new File("test2");


### PR DESCRIPTION
Based on the comments of #734 

- [x] STDIN Scanner is reverted to system default encoding considering there might be users using non-UTF8 passwords
- [x] ~~~findbugs-exclude.xml filter ruleset is added to exclude `DM_DEFAULT_ENCODING` in `ConsoleUtil`~~~
- [x] `Charset.defaultCharset()` is explicitly specified as the charset of STDIN input stream to fix `DM_DEFAULT_ENCODING`