### PR TITLE
Consensus: adding memoization to Vote#validate to avoid repeated validations

### DIFF
--- a/src/main/java/org/semux/consensus/SemuxBft.java
+++ b/src/main/java/org/semux/consensus/SemuxBft.java
@@ -638,7 +638,7 @@ public class SemuxBft implements Consensus {
             Vote vote = m.getVote();
 
             if (vote.getHeight() == height) {
-                if (vote.validate(true)) {
+                if (vote.revalidate()) {
                     events.add(new Event(Event.Type.VOTE, vote));
                 } else {
                     logger.debug("Invalid vote from {}", channel.getRemotePeer().getPeerId());

--- a/src/main/java/org/semux/consensus/SemuxBft.java
+++ b/src/main/java/org/semux/consensus/SemuxBft.java
@@ -638,7 +638,7 @@ public class SemuxBft implements Consensus {
             Vote vote = m.getVote();
 
             if (vote.getHeight() == height) {
-                if (vote.validate()) {
+                if (vote.validate(true)) {
                     events.add(new Event(Event.Type.VOTE, vote));
                 } else {
                     logger.debug("Invalid vote from {}", channel.getRemotePeer().getPeerId());

--- a/src/main/java/org/semux/consensus/Vote.java
+++ b/src/main/java/org/semux/consensus/Vote.java
@@ -102,7 +102,7 @@ public class Vote {
      * @return
      */
     public boolean validate() {
-        return validated.orElse(revalidate());
+        return validated.orElseGet(this::revalidate);
     }
 
     public VoteType getType() {

--- a/src/main/java/org/semux/consensus/Vote.java
+++ b/src/main/java/org/semux/consensus/Vote.java
@@ -35,6 +35,7 @@ public class Vote {
         this.height = height;
         this.view = view;
         this.blockHash = blockHash;
+        this.validated = Optional.empty();
 
         SimpleEncoder enc = new SimpleEncoder();
         enc.writeByte(type.toByte());
@@ -54,6 +55,7 @@ public class Vote {
         this.height = dec.readLong();
         this.view = dec.readInt();
         this.blockHash = dec.readBytes();
+        this.validated = Optional.empty();
 
         this.signature = Signature.fromBytes(signature);
     }

--- a/src/main/java/org/semux/consensus/Vote.java
+++ b/src/main/java/org/semux/consensus/Vote.java
@@ -25,6 +25,7 @@ public class Vote {
 
     private byte[] encoded;
     private Signature signature;
+    private Boolean validated;
 
     public Vote(VoteType type, boolean value, long height, int view, byte[] blockHash) {
         this.type = type;
@@ -79,13 +80,26 @@ public class Vote {
      * 
      * @return
      */
+    public boolean validate(boolean revalidate) {
+        if (revalidate) {
+            return (validated = type != null
+                    && height > 0
+                    && view >= 0
+                    && blockHash != null && blockHash.length == 32
+                    && encoded != null
+                    && signature != null && Key.verify(encoded, signature));
+        }
+        return validated != null ? validated
+                : (validated = type != null
+                        && height > 0
+                        && view >= 0
+                        && blockHash != null && blockHash.length == 32
+                        && encoded != null
+                        && signature != null && Key.verify(encoded, signature));
+    }
+
     public boolean validate() {
-        return type != null
-                && height > 0
-                && view >= 0
-                && blockHash != null && blockHash.length == 32
-                && encoded != null
-                && signature != null && Key.verify(encoded, signature);
+        return validate(false);
     }
 
     public VoteType getType() {


### PR DESCRIPTION
Currently, an incoming vote is validated 3 times (first time in onMessage, second time in onVote, and finally it is validated again when it's added to the VoteSet). To avoid that, a memoization is applied to Vote#validate. Forcing validation is possible by calling the overloaded Vote#validate with revalidate parameter set to true.