### PR TITLE
Trivial: comments and fix implementation specific code

### DIFF
--- a/src/main/java/org/semux/api/http/HttpHandler.java
+++ b/src/main/java/org/semux/api/http/HttpHandler.java
@@ -93,12 +93,8 @@ public class HttpHandler extends SimpleChannelInboundHandler<Object> {
 
             keepAlive = HttpUtil.isKeepAlive(request);
             uri = request.uri();
-            params = new QueryStringDecoder(request.uri(), CHARSET).parameters();
-            if (params.isEmpty()) {
-                // empty params has to be reinitialized as a instance of HashMap to avoid
-                // UnsupportedOperationException
-                params = new HashMap<>();
-            }
+            // copy collection to ensure it is writable
+            params = new HashMap<>(new QueryStringDecoder(request.uri(), CHARSET).parameters());
             headers = request.headers();
             body = Unpooled.buffer(MAX_BODY_SIZE);
 

--- a/src/main/java/org/semux/net/NodeManager.java
+++ b/src/main/java/org/semux/net/NodeManager.java
@@ -91,7 +91,7 @@ public class NodeManager {
 
             // every 0.5 seconds
             connectFuture = exec.scheduleAtFixedRate(this::doConnect, 100, 500, TimeUnit.MILLISECONDS);
-            // every 120 seconds, delayed by 10 seconds (public IP lookup)
+            // every 100 seconds, delayed by 5 seconds (public IP lookup)
             fetchFuture = exec.scheduleAtFixedRate(this::doFetch, 5, 100, TimeUnit.SECONDS);
 
             isRunning = true;


### PR DESCRIPTION
update comments to match implementation.
And for QueryStringDecoder, remove workaround for empty sets.
If implementation changes to use say Collections.singleton,
the existing code would break anyway.  If we're going to modify
list always make sure it's editable