### PR TITLE
API: include COINBASE transaction in block response

### DIFF
--- a/src/main/java/org/semux/api/v2_0_0/TypeFactory.java
+++ b/src/main/java/org/semux/api/v2_0_0/TypeFactory.java
@@ -8,6 +8,7 @@ package org.semux.api.v2_0_0;
 
 import static org.semux.core.TransactionType.DELEGATE;
 
+import java.util.List;
 import java.util.stream.Collectors;
 
 import org.semux.Kernel;
@@ -39,7 +40,11 @@ public class TypeFactory {
                 .transactionCount(transactionCount);
     }
 
-    public static BlockType blockType(Block block) {
+    public static BlockType blockType(Block block, Transaction coinbaseTransaction) {
+        List<Transaction> txs = block.getTransactions();
+        if (coinbaseTransaction != null) {
+            txs.add(0, coinbaseTransaction);
+        }
         return new BlockType()
                 .hash(Hex.encode0x(block.getHash()))
                 .number(String.valueOf(block.getNumber()))
@@ -52,7 +57,7 @@ public class TypeFactory {
                 .resultsRoot(Hex.encode0x(block.getResultsRoot()))
                 .stateRoot(Hex.encode0x(block.getStateRoot()))
                 .data(Hex.encode0x(block.getData()))
-                .transactions(block.getTransactions().stream()
+                .transactions(txs.stream()
                         .map(tx -> transactionType(block.getNumber(), tx))
                         .collect(Collectors.toList()));
     }

--- a/src/main/java/org/semux/api/v2_0_0/impl/SemuxApiServiceImpl.java
+++ b/src/main/java/org/semux/api/v2_0_0/impl/SemuxApiServiceImpl.java
@@ -261,7 +261,7 @@ public final class SemuxApiServiceImpl implements SemuxApi {
             return failure(resp, "The requested block was not found");
         }
 
-        resp.setResult(TypeFactory.blockType(block));
+        resp.setResult(TypeFactory.blockType(block, kernel.getBlockchain().getCoinbaseTransaction(block.getNumber())));
         resp.setSuccess(true);
         return Response.ok().entity(resp).build();
     }
@@ -286,7 +286,7 @@ public final class SemuxApiServiceImpl implements SemuxApi {
             return failure(resp, "The requested block was not found");
         }
 
-        resp.setResult(TypeFactory.blockType(block));
+        resp.setResult(TypeFactory.blockType(block, kernel.getBlockchain().getCoinbaseTransaction(block.getNumber())));
         resp.setSuccess(true);
         return Response.ok().entity(resp).build();
     }
@@ -339,7 +339,8 @@ public final class SemuxApiServiceImpl implements SemuxApi {
     @Override
     public Response getLatestBlock() {
         GetLatestBlockResponse resp = new GetLatestBlockResponse();
-        resp.setResult(TypeFactory.blockType(kernel.getBlockchain().getLatestBlock()));
+        Block block = kernel.getBlockchain().getLatestBlock();
+        resp.setResult(TypeFactory.blockType(block, kernel.getBlockchain().getCoinbaseTransaction(block.getNumber())));
         resp.setSuccess(true);
         return Response.ok().entity(resp).build();
     }

--- a/src/main/java/org/semux/core/Blockchain.java
+++ b/src/main/java/org/semux/core/Blockchain.java
@@ -101,6 +101,16 @@ public interface Blockchain {
     Transaction getTransaction(byte[] hash);
 
     /**
+     * Returns coinbase transaction of the block number. This method is required as
+     * Semux doesn't store coinbase transaction in blocks.
+     *
+     * @param blockNumber
+     *            the block number
+     * @return the coinbase transaction
+     */
+    Transaction getCoinbaseTransaction(long blockNumber);
+
+    /**
      * Returns whether the transaction is in the blockchain.
      *
      * @param hash

--- a/src/main/java/org/semux/core/BlockchainImpl.java
+++ b/src/main/java/org/semux/core/BlockchainImpl.java
@@ -86,6 +86,7 @@ public class BlockchainImpl implements Blockchain {
     protected static final byte TYPE_TRANSACTION_HASH = 0x04;
     protected static final byte TYPE_ACCOUNT_TRANSACTION = 0x05;
     protected static final byte TYPE_ACTIVATED_FORKS = 0x06;
+    protected static final byte TYPE_COINBASE_TRANSACTION_HASH = 0x07;
     protected static final byte TYPE_DATABASE_VERSION = (byte) 0xff;
 
     protected static final byte TYPE_BLOCK_HEADER = 0x00;
@@ -290,6 +291,13 @@ public class BlockchainImpl implements Blockchain {
     }
 
     @Override
+    public Transaction getCoinbaseTransaction(long blockNumber) {
+        return blockNumber == 0
+                ? null
+                : getTransaction(indexDB.get(Bytes.merge(TYPE_COINBASE_TRANSACTION_HASH, Bytes.of(blockNumber))));
+    }
+
+    @Override
     public boolean hasTransaction(final byte[] hash) {
         return indexDB.get(Bytes.merge(TYPE_TRANSACTION_HASH, hash)) != null;
     }
@@ -386,6 +394,7 @@ public class BlockchainImpl implements Blockchain {
                     Bytes.EMPTY_BYTES);
             tx.sign(Constants.COINBASE_KEY);
             indexDB.put(Bytes.merge(TYPE_TRANSACTION_HASH, tx.getHash()), tx.toBytes());
+            indexDB.put(Bytes.merge(TYPE_COINBASE_TRANSACTION_HASH, Bytes.of(block.getNumber())), tx.getHash());
             addTransactionToAccount(tx, block.getCoinbase());
 
             // [5] update validator statistics


### PR DESCRIPTION
This makes it easier for API consumers to account for block rewards.

### Tasks

- [x] BlockchainImpl: add `TYPE_COINBASE_TRANSACTION_HASH` index
- [x] API/TypeFactory: include COINBASE tx in block type