### PR TITLE
Wallet: Update security of wallet with bcrypt

### DIFF
--- a/src/main/java/org/semux/core/Wallet.java
+++ b/src/main/java/org/semux/core/Wallet.java
@@ -36,7 +36,8 @@ public class Wallet {
 
     private static final Logger logger = LoggerFactory.getLogger(Wallet.class);
 
-    private static final int VERSION = 2;
+    private static final int VERSION = 3;
+    private static final int HASH_ROUNDS = 100_000;
 
     private File file;
     private String password;
@@ -107,6 +108,14 @@ public class Wallet {
                     newAccounts = readAccounts(key, dec, false);
                     break;
                 case 2:
+                    newAccounts = readAccounts(key, dec, true);
+                    newAliases = readAddressAliases(key, dec);
+                    break;
+                case 3:
+                    // to discourage brute forcing, use many rounds of hashing
+                    for (int i = 0; i < HASH_ROUNDS; i++) {
+                        key = Hash.h256(key);
+                    }
                     newAccounts = readAccounts(key, dec, true);
                     newAliases = readAddressAliases(key, dec);
                     break;
@@ -433,6 +442,11 @@ public class Wallet {
 
             SimpleEncoder enc = new SimpleEncoder();
             enc.writeInt(VERSION);
+
+            // to discourage brute forcing, use many rounds of hashing.  We could memoize this.
+            for (int i = 0; i < HASH_ROUNDS; i++) {
+                key = Hash.h256(key);
+            }
 
             writeAccounts(key, enc);
             writeAddressAliases(key, enc);

--- a/src/main/java/org/semux/core/Wallet.java
+++ b/src/main/java/org/semux/core/Wallet.java
@@ -97,7 +97,7 @@ public class Wallet {
         }
 
         try {
-            byte[] key = Hash.h256(Bytes.of(password));
+            byte[] key;
 
             if (exists()) {
                 SimpleDecoder dec = new SimpleDecoder(IOUtil.readFile(file));
@@ -107,9 +107,11 @@ public class Wallet {
                 Map<ByteArray, String> newAliases = new HashMap<>();
                 switch (version) {
                 case 1:
+                    key = Hash.h256(Bytes.of(password));
                     newAccounts = readAccounts(key, dec, false, version);
                     break;
                 case 2:
+                    key = Hash.h256(Bytes.of(password));
                     newAccounts = readAccounts(key, dec, true, version);
                     newAliases = readAddressAliases(key, dec);
                     break;


### PR DESCRIPTION
Increment wallet version to add bcrypt hashing to generate
password for aes key.  This takes about 330ms on fairly
standard hardware.

fixes #758