### PR TITLE
 GUI: Notify user when there are updates 

### DIFF
--- a/src/main/java/org/semux/gui/SemuxGui.java
+++ b/src/main/java/org/semux/gui/SemuxGui.java
@@ -340,7 +340,7 @@ public class SemuxGui extends Launcher {
                 Version v = getCurrentVersions();
                 if (v != null && SystemUtil.compareVersion(Constants.CLIENT_VERSION, v.minVersion) < 0) {
                     JOptionPane.showMessageDialog(null, GuiMessages.get("WalletNeedToBeUpgraded"));
-                    SystemUtil.exitAsync(-1);
+                    SystemUtil.exitAsync(SystemUtil.Code.CLIENT_UPGRADE_NEEDED);
                 }
                 // notify user if a new version has been posted (once)
                 if (v != null && SystemUtil.compareVersion(Constants.CLIENT_VERSION, v.latestVersion) < 0

--- a/src/main/java/org/semux/gui/SemuxGui.java
+++ b/src/main/java/org/semux/gui/SemuxGui.java
@@ -341,6 +341,7 @@ public class SemuxGui extends Launcher {
                 if (v != null && SystemUtil.compareVersion(Constants.CLIENT_VERSION, v.minVersion) < 0) {
                     JOptionPane.showMessageDialog(null, GuiMessages.get("WalletNeedToBeUpgraded"));
                     SystemUtil.exitAsync(SystemUtil.Code.CLIENT_UPGRADE_NEEDED);
+                    return;
                 }
                 // notify user if a new version has been posted (once)
                 if (v != null && SystemUtil.compareVersion(Constants.CLIENT_VERSION, v.latestVersion) < 0

--- a/src/main/resources/org/semux/gui/messages.properties
+++ b/src/main/resources/org/semux/gui/messages.properties
@@ -6,7 +6,8 @@ SplashStartingKernel = Starting Kernel...
 # welcome frame
 SemuxWallet = Semux Wallet
 WelcomeDescriptionHtml = <html><h1>Welcome to semux!</h1><p>Do you want to create a new account or import accounts from backup files?</p></html>
-WalletNeedToBeUpgraded = Your wallet need to be upgraded!
+WalletNeedToBeUpgraded = Your wallet needs to be upgraded!
+WalletCanBeUpgraded = There is a new version of semux available!
 AccountSelection = Which account would you like to use?
 CreateNewAccount = Create new account
 ImportAccountsFromBackupFile = Import accounts from backup file

--- a/src/test/java/org/semux/gui/SemuxGuiTest.java
+++ b/src/test/java/org/semux/gui/SemuxGuiTest.java
@@ -124,8 +124,9 @@ public class SemuxGuiTest {
     @Test
     public void testGetMinVersion() {
         SemuxGui gui = spy(new SemuxGui());
-        String v = gui.getMinVersion();
-        logger.info("Min version: {}", v);
+        SemuxGui.Version v = gui.getCurrentVersions();
+        logger.info("Min version: {}", v.minVersion);
+        logger.info("Latest version: {}", v.latestVersion);
 
         assertThat(v).isNotNull();
     }


### PR DESCRIPTION
Update the loop for checking versions to
1) check at first startup, then every 8 hours, instead
of once every 5 minutes
2) Add check against latest to inform user when a new
version has been posted, but only notify them once per
session.

fixes #754