### PR TITLE
Consensus: add restrictions on coinbase & recipient

### DIFF
--- a/src/main/java/org/semux/consensus/SemuxBft.java
+++ b/src/main/java/org/semux/consensus/SemuxBft.java
@@ -11,6 +11,7 @@ import static org.semux.core.Amount.ZERO;
 import static org.semux.core.Amount.sum;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -24,6 +25,7 @@ import java.util.stream.Collectors;
 import org.semux.Kernel;
 import org.semux.Network;
 import org.semux.config.Config;
+import org.semux.config.Constants;
 import org.semux.consensus.SemuxBft.Event.Type;
 import org.semux.consensus.exception.SemuxBftException;
 import org.semux.core.Amount;
@@ -835,6 +837,11 @@ public class SemuxBft implements Consensus {
 
         if (header.getTimestamp() - System.currentTimeMillis() > config.maxBlockTimeDrift()) {
             logger.warn("A block in the future is not allowed");
+            return false;
+        }
+
+        if (Arrays.equals(header.getCoinbase(), Constants.COINBASE_KEY.toAddress())) {
+            logger.warn("A block forged by the coinbase magic account is not allowed");
             return false;
         }
 

--- a/src/main/java/org/semux/consensus/SemuxBft.java
+++ b/src/main/java/org/semux/consensus/SemuxBft.java
@@ -864,6 +864,11 @@ public class SemuxBft implements Consensus {
             return false;
         }
 
+        if (transactions.stream().anyMatch(tx -> Arrays.equals(tx.getTo(), Constants.COINBASE_KEY.toAddress()))) {
+            logger.warn("Sending transactions to coinbase magic account is not allowed");
+            return false;
+        }
+
         AccountState as = accountState.track();
         DelegateState ds = delegateState.track();
         TransactionExecutor exec = new TransactionExecutor(config);

--- a/src/main/java/org/semux/consensus/SemuxBft.java
+++ b/src/main/java/org/semux/consensus/SemuxBft.java
@@ -845,6 +845,11 @@ public class SemuxBft implements Consensus {
             return false;
         }
 
+        if (!Arrays.equals(header.getCoinbase(), proposal.getSignature().getAddress())) {
+            logger.warn("The coinbase should always equal to the proposer's address");
+            return false;
+        }
+
         // [2] check transactions and results (skipped)
         List<Transaction> unvalidatedTransactions = getUnvalidatedTransactions(transactions);
 

--- a/src/main/java/org/semux/consensus/SemuxSync.java
+++ b/src/main/java/org/semux/consensus/SemuxSync.java
@@ -379,6 +379,7 @@ public class SemuxSync implements SyncManager {
         // Added checks to UNIFORM_DISTRIBUTION fork:
         // - blocks should never be forged by coinbase magic account
         // - transactions should never be sent to coinbase magic account
+        // TODO: move checks to Transaction#validate after fork activation
         if (chain.forkActivated(block.getNumber(), UNIFORM_DISTRIBUTION)) {
             if (Arrays.equals(block.getCoinbase(), Constants.COINBASE_KEY.toAddress())) {
                 logger.warn("A block forged by the coinbase magic account is not allowed");

--- a/src/main/java/org/semux/core/BlockchainImpl.java
+++ b/src/main/java/org/semux/core/BlockchainImpl.java
@@ -343,15 +343,6 @@ public class BlockchainImpl implements Blockchain {
             throw new BlockchainException("Blocks can only be added sequentially");
         }
 
-        // set UNIFORM_DISTRIBUTION fork as the prerequisite of disallowing coinbase
-        // magic account from forging blocks to avoid potential network freeze caused by
-        // malicious users.
-        if (activatedForks.containsKey(UNIFORM_DISTRIBUTION)
-                && Arrays.equals(block.getCoinbase(), Constants.COINBASE_KEY.toAddress())) {
-            logger.error("Adding a block forged by coinbase magic account");
-            throw new BlockchainException("Coinbase magic account should never be used to forge blocks");
-        }
-
         // [1] update block
         blockDB.put(Bytes.merge(TYPE_BLOCK_HEADER, Bytes.of(number)), block.toBytesHeader());
         blockDB.put(Bytes.merge(TYPE_BLOCK_TRANSACTIONS, Bytes.of(number)), block.toBytesTransactions());

--- a/src/main/java/org/semux/core/BlockchainImpl.java
+++ b/src/main/java/org/semux/core/BlockchainImpl.java
@@ -343,6 +343,15 @@ public class BlockchainImpl implements Blockchain {
             throw new BlockchainException("Blocks can only be added sequentially");
         }
 
+        // set UNIFORM_DISTRIBUTION fork as the prerequisite of disallowing coinbase
+        // magic account from forging blocks to avoid potential network freeze caused by
+        // malicious users.
+        if (activatedForks.containsKey(UNIFORM_DISTRIBUTION)
+                && Arrays.equals(block.getCoinbase(), Constants.COINBASE_KEY.toAddress())) {
+            logger.error("Adding a block forged by coinbase magic account");
+            throw new BlockchainException("Coinbase magic account should never be used to forge blocks");
+        }
+
         // [1] update block
         blockDB.put(Bytes.merge(TYPE_BLOCK_HEADER, Bytes.of(number)), block.toBytesHeader());
         blockDB.put(Bytes.merge(TYPE_BLOCK_TRANSACTIONS, Bytes.of(number)), block.toBytesTransactions());

--- a/src/main/java/org/semux/core/PendingManager.java
+++ b/src/main/java/org/semux/core/PendingManager.java
@@ -7,6 +7,7 @@
 package org.semux.core;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
@@ -18,6 +19,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.semux.Kernel;
+import org.semux.config.Constants;
 import org.semux.core.state.AccountState;
 import org.semux.core.state.DelegateState;
 import org.semux.net.Channel;
@@ -304,6 +306,11 @@ public class PendingManager implements Runnable, BlockchainListener {
         if (tx.getTimestamp() < now - kernel.getConfig().maxTransactionTimeDrift()
                 || tx.getTimestamp() > now + kernel.getConfig().maxTransactionTimeDrift()) {
             return new ProcessTransactionResult(0, TransactionResult.Error.INVALID_TIMESTAMP);
+        }
+
+        // reject transactions sending to coinbase magic account
+        if (Arrays.equals(tx.getTo(), Constants.COINBASE_KEY.toAddress())) {
+            return new ProcessTransactionResult(0, TransactionResult.Error.INVALID_RECIPIENT);
         }
 
         // Check transaction nonce: pending transactions must be executed sequentially

--- a/src/main/java/org/semux/core/TransactionResult.java
+++ b/src/main/java/org/semux/core/TransactionResult.java
@@ -78,6 +78,11 @@ public class TransactionResult {
         INVALID_DELEGATE_BURN_AMOUNT,
 
         /**
+         * Invalid transaction recipient.
+         */
+        INVALID_RECIPIENT,
+
+        /**
          * Transaction failed.
          */
         FAILED

--- a/src/test/java/org/semux/TestUtils.java
+++ b/src/test/java/org/semux/TestUtils.java
@@ -52,7 +52,7 @@ public class TestUtils {
         Network network = config.network();
         TransactionType type = TransactionType.TRANSFER;
         Amount fee = Amount.ZERO;
-        long nonce = 1;
+        long nonce = 0;
         long timestamp = System.currentTimeMillis();
         byte[] data = {};
 

--- a/src/test/java/org/semux/TestUtils.java
+++ b/src/test/java/org/semux/TestUtils.java
@@ -23,16 +23,19 @@ import org.semux.util.MerkleUtil;
 public class TestUtils {
 
     public static Block createBlock(long number, List<Transaction> txs, List<TransactionResult> res) {
-        Key key = new Key();
-        byte[] coinbase = key.toAddress();
-        byte[] prevHash = Bytes.EMPTY_HASH;
+        return createBlock(Bytes.EMPTY_HASH, new Key(), number, txs, res);
+    }
+
+    public static Block createBlock(byte[] prevHash, Key coinbase, long number, List<Transaction> txs,
+            List<TransactionResult> res) {
         long timestamp = System.currentTimeMillis();
         byte[] transactionsRoot = MerkleUtil.computeTransactionsRoot(txs);
         byte[] resultsRoot = MerkleUtil.computeResultsRoot(res);
         byte[] stateRoot = Bytes.EMPTY_HASH;
         byte[] data = {};
 
-        BlockHeader header = new BlockHeader(number, coinbase, prevHash, timestamp, transactionsRoot, resultsRoot,
+        BlockHeader header = new BlockHeader(number, coinbase.toAddress(), prevHash, timestamp, transactionsRoot,
+                resultsRoot,
                 stateRoot, data);
         return new Block(header, txs, res);
     }

--- a/src/test/java/org/semux/consensus/SemuxBftTest.java
+++ b/src/test/java/org/semux/consensus/SemuxBftTest.java
@@ -29,6 +29,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.semux.TestUtils;
 import org.semux.config.Constants;
 import org.semux.config.MainnetConfig;
 import org.semux.core.Block;
@@ -168,6 +169,21 @@ public class SemuxBftTest {
                         new TransactionResult(false))));
 
         assertFalse(semuxBFT.getUnvalidatedTransactions(Collections.singletonList(tx2)).isEmpty());
+    }
+
+    @Test
+    public void testValidateBlockCoinbase() {
+        kernelRule.getKernel().setBlockchain(new BlockchainImpl(kernelRule.getKernel().getConfig(), temporaryDBRule));
+
+        Block block = TestUtils.createBlock(
+                kernelRule.getKernel().getBlockchain().getLatestBlock().getHash(),
+                Constants.COINBASE_KEY,
+                1,
+                Collections.emptyList(),
+                Collections.emptyList());
+
+        SemuxBft semuxBFT = new SemuxBft(kernelRule.getKernel());
+        assertFalse(semuxBFT.validateBlock(block.getHeader(), Collections.emptyList()));
     }
 
     private Transaction createTransaction(Key to, Key from, long time, long nonce) {

--- a/src/test/java/org/semux/core/PendingManagerTest.java
+++ b/src/test/java/org/semux/core/PendingManagerTest.java
@@ -28,6 +28,7 @@ import org.junit.Test;
 import org.mockito.Mockito;
 import org.semux.KernelMock;
 import org.semux.Network;
+import org.semux.config.Constants;
 import org.semux.core.state.AccountState;
 import org.semux.crypto.Key;
 import org.semux.db.LeveldbDatabase.LevelDbFactory;
@@ -126,6 +127,19 @@ public class PendingManagerTest {
         assertEquals(TransactionResult.Error.DUPLICATED_HASH, result.error);
 
         Mockito.reset(kernel.getBlockchain());
+    }
+
+    @Test
+    public void testAddTransactionSyncInvalidRecipient() {
+        Transaction tx = new Transaction(network, type, Constants.COINBASE_KEY.toAddress(), value, fee, 0,
+                System.currentTimeMillis(),
+                Bytes.EMPTY_BYTES)
+                        .sign(key);
+
+        PendingManager.ProcessTransactionResult result = pendingMgr.addTransactionSync(tx);
+        assertEquals(0, pendingMgr.getPendingTransactions().size());
+        assertNotNull(result.error);
+        assertEquals(TransactionResult.Error.INVALID_RECIPIENT, result.error);
     }
 
     @Test


### PR DESCRIPTION
fix #786

### Added Restrictions

- [x] BFT & Sync: Disallow `Constants.COINBASE_KEY` 
- [x] BFT: Block#coinbase should always equal to `proposal.getSignature().getAddress()`
- [x] BFT & Sync & PendingManager: Disallow sending txs to coinbase magic account