### PR TITLE
Util: adjust test log levels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ hs_err_pid*
 
 # ignore generated files
 src/gen
+
+# ignore slf4j test config
+src/test/resources/log4j2-test.xml

--- a/config/log4j2.xml
+++ b/config/log4j2.xml
@@ -28,8 +28,8 @@
         <Logger name="org.semux.wrapper" level="INFO" />
 
         <Logger name="io.netty" level="ERROR" />
-        <Logger name="oshi" level="INFO" />
         <Logger name="io.swagger" level="ERROR" />
+        <Logger name="oshi" level="INFO" />
 
         <Root level="INFO">
             <AppenderRef ref="Async" />

--- a/src/main/java/org/semux/event/PubSub.java
+++ b/src/main/java/org/semux/event/PubSub.java
@@ -89,7 +89,7 @@ public class PubSub {
      * @return whether the event is successfully unsubscribed.
      */
     public boolean unsubscribe(PubSubSubscriber subscriber, Class<? extends PubSubEvent> event) {
-        ConcurrentLinkedQueue q = subscribers.get(event);
+        ConcurrentLinkedQueue<?> q = subscribers.get(event);
         if (q != null) {
             return q.remove(subscriber);
         } else {

--- a/src/main/java/org/semux/gui/SplashScreen.java
+++ b/src/main/java/org/semux/gui/SplashScreen.java
@@ -69,7 +69,6 @@ public class SplashScreen extends JFrame implements PubSubSubscriber {
         showSplash();
     }
 
-    @SuppressWarnings("unchecked")
     private void subscribeEvents() {
         pubSub.subscribe(
                 this,

--- a/src/main/java/org/semux/log/LoggerConfigurator.java
+++ b/src/main/java/org/semux/log/LoggerConfigurator.java
@@ -44,12 +44,13 @@ public class LoggerConfigurator {
 
             // register configuration error listener
             StatusListener errorStatusListener = new ConfigurationErrorStatusListener();
+            StatusLogger.getLogger().setLevel(Level.OFF);
+            StatusLogger.getLogger().reset();
             StatusLogger.getLogger().registerListener(errorStatusListener);
 
             // load configuration
             final LoggerContext context = (LoggerContext) LogManager.getContext(false);
             context.setConfigLocation(file.toURI());
-            context.reconfigure();
             context.updateLoggers();
 
             // remove configuration error listener

--- a/src/main/java/org/semux/net/filter/SemuxIpFilter.java
+++ b/src/main/java/org/semux/net/filter/SemuxIpFilter.java
@@ -265,7 +265,7 @@ public class SemuxIpFilter {
 
                 new ObjectMapper().writer(SerializationFeature.INDENT_OUTPUT).writeValue(path.toFile(), ipFilter);
             } catch (IOException e) {
-                logger.error("Failed to save ip filter", e);
+                logger.error("Failed to save ip filter: {}", e.getMessage());
             }
         }
 

--- a/src/test/java/org/semux/api/v1_0_1/ApiHandlerErrorTest.java
+++ b/src/test/java/org/semux/api/v1_0_1/ApiHandlerErrorTest.java
@@ -26,6 +26,8 @@ import org.semux.api.SemuxApiMock;
 import org.semux.crypto.Hex;
 import org.semux.rules.KernelRule;
 import org.semux.util.Bytes;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The test case covers validation rules of {@link ApiHandlerImpl}
@@ -34,6 +36,8 @@ import org.semux.util.Bytes;
  */
 @RunWith(Parameterized.class)
 public class ApiHandlerErrorTest extends ApiHandlerTestBase {
+
+    private static final Logger logger = LoggerFactory.getLogger(ApiHandlerErrorTest.class);
 
     private static final String ADDRESS_PLACEHOLDER = "[wallet]";
 
@@ -119,7 +123,7 @@ public class ApiHandlerErrorTest extends ApiHandlerTestBase {
         assertFalse(response.success);
         assertNotNull(response.message);
 
-        System.out.println(response.message);
+        logger.info(response.message);
     }
 
     private static String randomHex() {

--- a/src/test/java/org/semux/integration/ConnectionTest.java
+++ b/src/test/java/org/semux/integration/ConnectionTest.java
@@ -89,7 +89,7 @@ public class ConnectionTest {
     }
 
     @After
-    public void tearDown() throws InterruptedException {
+    public void tearDown() {
         // close all connections
         sockets.parallelStream().filter(Objects::nonNull).forEach(socket -> {
             try {

--- a/src/test/resources/log4j2-test.xml
+++ b/src/test/resources/log4j2-test.xml
@@ -7,17 +7,17 @@
         </Console>
     </Appenders>
     <Loggers>
-        <Logger name="org.semux.api" level="DEBUG" />
-        <Logger name="org.semux.core" level="DEBUG" />
-        <Logger name="org.semux.consensus" level="DEBUG" />
-        <Logger name="org.semux.db" level="DEBUG" />
-        <Logger name="org.semux.net" level="DEBUG" />
-        <Logger name="org.semux.vm" level="DEBUG" />
-        <Logger name="org.semux.wrapper" level="DEBUG" />
+        <Logger name="org.semux.api" level="INFO" />
+        <Logger name="org.semux.core" level="INFO" />
+        <Logger name="org.semux.consensus" level="INFO" />
+        <Logger name="org.semux.db" level="INFO" />
+        <Logger name="org.semux.net" level="INFO" />
+        <Logger name="org.semux.vm" level="INFO" />
+        <Logger name="org.semux.wrapper" level="INFO" />
 
         <Logger name="io.netty" level="ERROR" />
-        <Logger name="oshi" level="DEBUG" />
         <Logger name="io.swagger" level="ERROR" />
+        <Logger name="oshi" level="INFO" />
 
         <Root level="DEBUG">
             <AppenderRef ref="Console"/>


### PR DESCRIPTION
The CI logs are too long to read. Time to clean up.

Still haven't figured out how to disable logs from `KernelRule`