### PR TITLE
Improper initialization of HttpHandler causing serious API performance degrade

### DIFF
--- a/src/main/java/org/semux/api/Version.java
+++ b/src/main/java/org/semux/api/Version.java
@@ -6,23 +6,24 @@
  */
 package org.semux.api;
 
-import org.semux.util.exception.UnreachableException;
+import java.util.function.Function;
+
+import org.semux.Kernel;
+import org.semux.api.v1_0_1.ApiHandlerImpl;
 
 public enum Version {
 
-    v1_0_1,
+    v1_0_1("v1.0.1", ApiHandlerImpl::new),
 
-    v2_0_0;
+    v2_0_0("v2.0.0", org.semux.api.v2_0_0.impl.ApiHandlerImpl::new);
 
-    public static String prefixOf(Version version) {
-        switch (version) {
-        case v1_0_1:
-            return "v1.0.1";
-        case v2_0_0:
-            return "v2.0.0";
-        default:
-            throw new UnreachableException();
-        }
+    public final String prefix;
+
+    public final Function<Kernel, ApiHandler> apiHandlerFactory;
+
+    Version(String prefix, Function<Kernel, ApiHandler> apiHandlerFactory) {
+        this.prefix = prefix;
+        this.apiHandlerFactory = apiHandlerFactory;
     }
 
     public static Version fromPrefix(String prefix) {

--- a/src/main/java/org/semux/api/Version.java
+++ b/src/main/java/org/semux/api/Version.java
@@ -6,24 +6,16 @@
  */
 package org.semux.api;
 
-import java.util.function.Function;
-
-import org.semux.Kernel;
-import org.semux.api.v1_0_1.ApiHandlerImpl;
-
 public enum Version {
 
-    v1_0_1("v1.0.1", ApiHandlerImpl::new),
+    v1_0_1("v1.0.1"),
 
-    v2_0_0("v2.0.0", org.semux.api.v2_0_0.impl.ApiHandlerImpl::new);
+    v2_0_0("v2.0.0");
 
     public final String prefix;
 
-    public final Function<Kernel, ApiHandler> apiHandlerFactory;
-
-    Version(String prefix, Function<Kernel, ApiHandler> apiHandlerFactory) {
+    Version(String prefix) {
         this.prefix = prefix;
-        this.apiHandlerFactory = apiHandlerFactory;
     }
 
     public static Version fromPrefix(String prefix) {

--- a/src/main/java/org/semux/api/http/HttpHandler.java
+++ b/src/main/java/org/semux/api/http/HttpHandler.java
@@ -85,15 +85,13 @@ public class HttpHandler extends SimpleChannelInboundHandler<FullHttpRequest> {
     private static final Pattern STATIC_FILE_PATTERN = Pattern.compile("^.+\\.(html|json|js|css|png)$");
 
     private Config config;
-    private Map<Version, ApiHandler> apiHandlers = new ConcurrentHashMap<>();
+    private final Map<Version, ApiHandler> apiHandlers;
 
     private Boolean isKeepAlive = false;
 
-    @SuppressWarnings("deprecation")
-    public HttpHandler(Kernel kernel) {
+    public HttpHandler(Kernel kernel, final Map<Version, ApiHandler> apiHandlers) {
         this.config = kernel.getConfig();
-        this.apiHandlers.put(Version.v1_0_1, new org.semux.api.v1_0_1.ApiHandlerImpl(kernel));
-        this.apiHandlers.put(Version.v2_0_0, new org.semux.api.v2_0_0.impl.ApiHandlerImpl(kernel));
+        this.apiHandlers = apiHandlers;
     }
 
     /**
@@ -106,6 +104,7 @@ public class HttpHandler extends SimpleChannelInboundHandler<FullHttpRequest> {
      */
     protected HttpHandler(Config config, ApiHandler apiHandler) {
         this.config = config;
+        this.apiHandlers = new ConcurrentHashMap<>();
         for (Version version : Version.values()) {
             this.apiHandlers.put(version, apiHandler);
         }

--- a/src/main/java/org/semux/api/http/SemuxApiService.java
+++ b/src/main/java/org/semux/api/http/SemuxApiService.java
@@ -6,10 +6,13 @@
  */
 package org.semux.api.http;
 
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.semux.Kernel;
+import org.semux.api.ApiHandler;
 import org.semux.api.Version;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -47,11 +50,17 @@ public class SemuxApiService {
     private EventLoopGroup bossGroup;
     private EventLoopGroup workerGroup;
 
+    private final Map<Version, ApiHandler> apiHandlers;
+
     String ip;
     int port;
 
     public SemuxApiService(Kernel kernel) {
         this.kernel = kernel;
+
+        this.apiHandlers = new ConcurrentHashMap<>();
+        this.apiHandlers.put(Version.v1_0_1, new org.semux.api.v1_0_1.ApiHandlerImpl(kernel));
+        this.apiHandlers.put(Version.v2_0_0, new org.semux.api.v2_0_0.impl.ApiHandlerImpl(kernel));
     }
 
     /**
@@ -147,7 +156,7 @@ public class SemuxApiService {
 
         @Override
         public HttpHandler initHandler() {
-            return new HttpHandler(kernel);
+            return new HttpHandler(kernel, apiHandlers);
         }
     }
 }

--- a/src/main/java/org/semux/api/http/SemuxApiService.java
+++ b/src/main/java/org/semux/api/http/SemuxApiService.java
@@ -6,10 +6,12 @@
  */
 package org.semux.api.http;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 
 import org.semux.Kernel;
 import org.semux.api.ApiHandler;
@@ -57,10 +59,11 @@ public class SemuxApiService {
 
     public SemuxApiService(Kernel kernel) {
         this.kernel = kernel;
-
-        this.apiHandlers = new ConcurrentHashMap<>();
-        this.apiHandlers.put(Version.v1_0_1, new org.semux.api.v1_0_1.ApiHandlerImpl(kernel));
-        this.apiHandlers.put(Version.v2_0_0, new org.semux.api.v2_0_0.impl.ApiHandlerImpl(kernel));
+        this.apiHandlers = Collections
+                .unmodifiableMap(Arrays.stream(Version.values())
+                        .collect(Collectors.toMap(
+                                v -> v,
+                                v -> v.apiHandlerFactory.apply(kernel))));
     }
 
     /**
@@ -142,11 +145,11 @@ public class SemuxApiService {
     }
 
     public String getAPIUrl() {
-        return String.format("http://%s:%d/%s/", ip, port, Version.prefixOf(DEFAULT_VERSION));
+        return String.format("http://%s:%d/%s/", ip, port, DEFAULT_VERSION.prefix);
     }
 
     public String getSwaggerUrl() {
-        return String.format("http://%s:%d/%s/swagger.html", ip, port, Version.prefixOf(DEFAULT_VERSION));
+        return String.format("http://%s:%d/%s/swagger.html", ip, port, DEFAULT_VERSION.prefix);
     }
 
     /**

--- a/src/main/java/org/semux/api/http/SemuxApiService.java
+++ b/src/main/java/org/semux/api/http/SemuxApiService.java
@@ -63,7 +63,15 @@ public class SemuxApiService {
                 .unmodifiableMap(Arrays.stream(Version.values())
                         .collect(Collectors.toMap(
                                 v -> v,
-                                v -> v.apiHandlerFactory.apply(kernel))));
+                                v -> {
+                                    if (v.equals(Version.v1_0_1)) {
+                                        return new org.semux.api.v1_0_1.ApiHandlerImpl(kernel);
+                                    } else if (v.equals(Version.v2_0_0)) {
+                                        return new org.semux.api.v2_0_0.impl.ApiHandlerImpl(kernel);
+                                    } else {
+                                        return null;
+                                    }
+                                })));
     }
 
     /**

--- a/src/main/java/org/semux/api/v1_0_1/ApiHandlerImpl.java
+++ b/src/main/java/org/semux/api/v1_0_1/ApiHandlerImpl.java
@@ -40,7 +40,7 @@ public class ApiHandlerImpl implements ApiHandler {
     @Override
     public ApiHandlerResponse service(HttpMethod method, String uri, Map<String, String> params, HttpHeaders headers) {
         // strip version prefix
-        uri = uri.replaceAll("^/" + Version.prefixOf(Version.v1_0_1), "");
+        uri = uri.replaceAll("^/" + Version.v1_0_1.prefix, "");
 
         if ("/".equals(uri)) {
             return new GetRootResponse(true, "Semux API works");

--- a/src/test/java/org/semux/api/http/HttpHandlerTest.java
+++ b/src/test/java/org/semux/api/http/HttpHandlerTest.java
@@ -160,7 +160,7 @@ public class HttpHandlerTest {
     public void testGetStaticFiles404() throws IOException {
         startServer(null);
 
-        URL url = new URL("http://" + ip + ":" + port + "/" + Version.prefixOf(Version.v2_0_0) + "/xx.html");
+        URL url = new URL("http://" + ip + ":" + port + "/" + Version.v2_0_0.prefix + "/xx.html");
         HttpURLConnection con = (HttpURLConnection) url.openConnection();
         con.setRequestProperty("Authorization", auth);
 

--- a/src/test/java/org/semux/api/v2_0_0/SemuxApiErrorTest.java
+++ b/src/test/java/org/semux/api/v2_0_0/SemuxApiErrorTest.java
@@ -209,7 +209,7 @@ public class SemuxApiErrorTest extends SemuxApiTestBase {
 
         WebClient webClient = WebClient.create(
                 String.format("http://%s:%d/%s%s", config.apiListenIp(), config.apiListenPort(),
-                        Version.prefixOf(Version.v2_0_0), uriString),
+                        Version.v2_0_0.prefix, uriString),
                 Collections.singletonList(new JacksonJsonProvider(
                         new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false))),
                 config.apiUsername(),

--- a/src/test/java/org/semux/api/v2_0_0/SemuxApiTestBase.java
+++ b/src/test/java/org/semux/api/v2_0_0/SemuxApiTestBase.java
@@ -62,7 +62,7 @@ public abstract class SemuxApiTestBase {
         channelMgr = apiMock.getKernel().getChannelManager();
 
         api = JAXRSClientFactory.create(
-                "http://localhost:51710/" + Version.prefixOf(Version.v2_0_0),
+                "http://localhost:51710/" + Version.v2_0_0.prefix,
                 org.semux.api.v2_0_0.client.SemuxApi.class,
                 Collections.singletonList(new JacksonJsonProvider()),
                 config.apiUsername(),


### PR DESCRIPTION
`Map<Version, ApiHandler> apiHandlers` should be initialized for only once.

Related: #704 