### PR TITLE
Tools: remove appbundle & change java download url to oracle's site

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -324,7 +324,7 @@
                             <headerType>gui</headerType>
                             <jar>${project.build.directory}/${project.artifactId}-${project.version}-shaded.jar</jar>
                             <outfile>${project.build.directory}/semux.exe</outfile>
-                            <downloadUrl>http://java.com/download</downloadUrl>
+                            <downloadUrl>http://www.oracle.com/technetwork/java/javase/downloads/jre8-downloads-2133155.html</downloadUrl>
                             <classPath>
                                 <mainClass>org.semux.gui.SemuxGui</mainClass>
                                 <preCp>anything</preCp>
@@ -357,38 +357,6 @@
                                 <mutexName>semux</mutexName>
                             </singleInstance>
                         </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-
-            <!-- build macos executable -->
-            <plugin>
-                <groupId>sh.tak.appbundler</groupId>
-                <artifactId>appbundle-maven-plugin</artifactId>
-                <version>1.2.0</version>
-                <configuration>
-                    <mainClass>org.semux.wrapper.Wrapper</mainClass>
-                    <workingDirectory>$APP_ROOT/..</workingDirectory>
-                    <!-- <generateDiskImageFile>true</generateDiskImageFile> -->
-                    <jvmVersion>1.8</jvmVersion>
-                    <version>${project.version}-${git.commit.id.abbrev}</version>
-                    <iconFile>logo.icns</iconFile>
-                    <additionalResources>
-                        <additionalResource>
-                            <includes>
-                                <include>config/**</include>
-                                <include>LICENSE*</include>
-                            </includes>
-                            <directory>${project.basedir}</directory>
-                        </additionalResource>
-                    </additionalResources>
-                </configuration>
-                <executions>
-                    <execution>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>bundle</goal>
-                        </goals>
                     </execution>
                 </executions>
             </plugin>
@@ -681,7 +649,6 @@
                                         <urn>org.xerial.snappy:snappy-java:1.1.7.1:jar:null:compile:d5190b41f3de61e3b83d692322d58630252bc8c3</urn>
                                         <urn>org.yaml:snakeyaml:1.18:jar:null:compile:e4a441249ade301985cb8d009d4e4a72b85bf68e</urn>
                                         <urn>pl.project13.maven:git-commit-id-plugin:2.2.4:maven-plugin:null:runtime:43a0dc1d02821c51847d587ecc4a6943086b884c</urn>
-                                        <urn>sh.tak.appbundler:appbundle-maven-plugin:1.2.0:maven-plugin:null:runtime:75a9e8c2adc7203b9b443b4547570da25c619f0d</urn>
                                     </urns>
                                 </digestRule>
                             </rules>


### PR DESCRIPTION
- [x] remove appbundle: appbundle is not being used for now fix #807 
- [x] change java download url to oracle's site: java.com provides 32-bit version of jvm regardless user's os architecture 