### PR TITLE
Tools: change Docker base image to debian as native libs aren't supported on alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM openjdk:8-jre-alpine
+FROM openjdk:8-jre
 
 WORKDIR /
 
-RUN apk --no-cache add curl jq
+RUN apt-get update && apt-get install --yes curl jq
 
 RUN LATEST=`curl -s https://api.github.com/repos/semuxproject/semux/releases/latest | jq '.assets[]  | select(.name | contains("linux"))'` && \
     LINK=`echo ${LATEST} | jq -r '.browser_download_url'` && \
@@ -12,7 +12,7 @@ RUN LATEST=`curl -s https://api.github.com/repos/semuxproject/semux/releases/lat
     tar -xzf ${TARBALL} -C /semux --strip-components=1 && \
     rm ${TARBALL}
 
-RUN apk del curl jq
+RUN apt-get remove --yes curl jq
 
 EXPOSE 5161
 


### PR DESCRIPTION
```
semux_1  | 23:35:04.164 WARN     Native           Failed to load native library: /native/linux64/libsodium.so.23
semux_1  | java.lang.UnsatisfiedLinkError: /tmp/native8896693692344773996/libsodium.so.23: Error relocating /tmp/native8896693692344773996/libsodium.so.23: __memcpy_chk: symbol not found
semux_1  |      at java.lang.ClassLoader$NativeLibrary.load(Native Method) ~[?:1.8.0_151]
semux_1  |      at java.lang.ClassLoader.loadLibrary0(ClassLoader.java:1941) ~[?:1.8.0_151]
semux_1  |      at java.lang.ClassLoader.loadLibrary(ClassLoader.java:1824) ~[?:1.8.0_151]
semux_1  |      at java.lang.Runtime.load0(Runtime.java:809) ~[?:1.8.0_151]
semux_1  |      at java.lang.System.load(System.java:1086) ~[?:1.8.0_151]
semux_1  |      at org.semux.crypto.Native.loadLibrary(Native.java:85) [semux.jar:a9b0ae0]
semux_1  |      at org.semux.crypto.Native.init(Native.java:40) [semux.jar:a9b0ae0]
semux_1  |      at org.semux.crypto.Native.<clinit>(Native.java:95) [semux.jar:a9b0ae0]
semux_1  |      at org.semux.crypto.Hash.h160(Hash.java:69) [semux.jar:a9b0ae0]
semux_1  |      at org.semux.crypto.Key.toAddress(Key.java:133) [semux.jar:a9b0ae0]
semux_1  |      at org.semux.core.Wallet.unlock(Wallet.java:143) [semux.jar:a9b0ae0]
semux_1  |      at org.semux.cli.SemuxCli.loadAndUnlockWallet(SemuxCli.java:322) [semux.jar:a9b0ae0]
semux_1  |      at org.semux.cli.SemuxCli.start(SemuxCli.java:161) [semux.jar:a9b0ae0]
semux_1  |      at org.semux.cli.SemuxCli.start(SemuxCli.java:145) [semux.jar:a9b0ae0]
semux_1  |      at org.semux.cli.SemuxCli.main(SemuxCli.java:50) [semux.jar:a9b0ae0]
```