### PR TITLE
API: default transaction fee param to min tx fee

### DIFF
--- a/src/main/java/org/semux/api/util/TransactionBuilder.java
+++ b/src/main/java/org/semux/api/util/TransactionBuilder.java
@@ -168,8 +168,9 @@ public class TransactionBuilder {
     }
 
     public TransactionBuilder withFee(String fee) {
-        if (fee == null) {
-            throw new IllegalArgumentException("Parameter `fee` is required");
+        if (fee == null || fee.isEmpty()) {
+            this.fee = kernel.getConfig().minTransactionFee();
+            return this;
         }
 
         try {

--- a/src/main/java/org/semux/api/v2_0_0/impl/SemuxApiServiceImpl.java
+++ b/src/main/java/org/semux/api/v2_0_0/impl/SemuxApiServiceImpl.java
@@ -498,7 +498,7 @@ public final class SemuxApiServiceImpl implements SemuxApi {
     }
 
     @Override
-    public Response registerDelegate(String from, String fee, String delegateName) {
+    public Response registerDelegate(String from, String delegateName, String fee) {
         return doTransaction(TransactionType.DELEGATE, from, null, null, fee, delegateName);
     }
 

--- a/src/main/resources/org/semux/api/v2_0_0/swagger.json
+++ b/src/main/resources/org/semux/api/v2_0_0/swagger.json
@@ -867,7 +867,7 @@
                         "name" : "fee",
                         "in" : "query",
                         "description" : "Transaction fee",
-                        "required" : true,
+                        "required" : false,
                         "type" : "string",
                         "format" : "int64",
                         "pattern" : "^\\d+$"
@@ -876,7 +876,7 @@
                         "name" : "data",
                         "in" : "query",
                         "description" : "Transaction data",
-                        "required" : true,
+                        "required" : false,
                         "type" : "string",
                         "pattern" : "^(0x)?[0-9a-fA-F]+$"
                     }
@@ -935,7 +935,7 @@
                         "name" : "fee",
                         "in" : "query",
                         "description" : "Transaction fee",
-                        "required" : true,
+                        "required" : false,
                         "type" : "string",
                         "format" : "int64",
                         "pattern" : "^\\d+$"
@@ -995,7 +995,7 @@
                         "name" : "fee",
                         "in" : "query",
                         "description" : "Transaction fee",
-                        "required" : true,
+                        "required" : false,
                         "type" : "string",
                         "format" : "int64",
                         "pattern" : "^\\d+$"
@@ -1039,7 +1039,7 @@
                         "name" : "fee",
                         "in" : "query",
                         "description" : "Transaction fee",
-                        "required" : true,
+                        "required" : false,
                         "type" : "string",
                         "format" : "int64",
                         "pattern" : "^\\d+$"

--- a/src/test/java/org/semux/api/v2_0_0/SemuxApiErrorTest.java
+++ b/src/test/java/org/semux/api/v2_0_0/SemuxApiErrorTest.java
@@ -152,10 +152,6 @@ public class SemuxApiErrorTest extends SemuxApiTestBase {
                         uriBuilder("transfer").queryParam("from", ADDRESS_PLACEHOLDER).queryParam("to", randomHex())
                                 .queryParam("value", "_").build() },
 
-                { POST.class,
-                        uriBuilder("transfer").queryParam("from", ADDRESS_PLACEHOLDER).queryParam("to", randomHex())
-                                .queryParam("value", "10").build() },
-
                 // non-number
                 { POST.class,
                         uriBuilder("transfer").queryParam("from", ADDRESS_PLACEHOLDER).queryParam("to", randomHex())


### PR DESCRIPTION
As users input the fee as minimum in most cases, it makes more sense to make the fee parameter become optional and default to 0.005 SEM.