### PR TITLE
Consensus: optimize SemuxSync#validateBlock

### DIFF
--- a/src/main/java/org/semux/consensus/SemuxSync.java
+++ b/src/main/java/org/semux/consensus/SemuxSync.java
@@ -424,8 +424,8 @@ public class SemuxSync implements SyncManager {
             return false;
         }
 
-        // [4] evaluate votes
-        return validateBlockVotes(block);
+        // [4] evaluate votes per validator set update
+        return header.getNumber() % config.getValidatorUpdateInterval() != 0 || validateBlockVotes(block);
     }
 
     protected boolean validateBlockVotes(Block block) {


### PR DESCRIPTION
fix #803 

A local benchmark with Intel E3-1231 + JVM 8 shows that about 60 seconds of CPU time is saved per 10K blocks with the optimization.