### PR TITLE
API: remove BlockType#date in favour of BlockType#timestamp

### DIFF
--- a/src/main/java/org/semux/api/v2_0_0/TypeFactory.java
+++ b/src/main/java/org/semux/api/v2_0_0/TypeFactory.java
@@ -32,7 +32,6 @@ import org.semux.core.state.Account;
 import org.semux.core.state.Delegate;
 import org.semux.crypto.Hex;
 import org.semux.net.Peer;
-import org.semux.util.TimeUtil;
 
 public class TypeFactory {
 
@@ -58,7 +57,6 @@ public class TypeFactory {
                 .coinbase(Hex.encode0x(block.getCoinbase()))
                 .parentHash(Hex.encode0x(block.getParentHash()))
                 .timestamp(String.valueOf(block.getTimestamp()))
-                .date(TimeUtil.formatTimestamp(block.getTimestamp()))
                 .transactionsRoot(Hex.encode0x(block.getTransactionsRoot()))
                 .resultsRoot(Hex.encode0x(block.getResultsRoot()))
                 .stateRoot(Hex.encode0x(block.getStateRoot()))

--- a/src/main/resources/org/semux/api/v2_0_0/swagger.json
+++ b/src/main/resources/org/semux/api/v2_0_0/swagger.json
@@ -1458,10 +1458,6 @@
                     "format" : "int64",
                     "pattern" : "^\\d+$"
                 },
-                "date" : {
-                    "type" : "string",
-                    "pattern": "^\\d{4}-\\d{2}-\\d{2} \\d{2}-\\d{2}-\\d{2}$"
-                },
                 "transactionsRoot" : {
                     "type" : "string",
                     "pattern" : "^(0x)?[0-9a-fA-F]{64}$"

--- a/src/test/java/org/semux/api/v2_0_0/SemuxApiTest.java
+++ b/src/test/java/org/semux/api/v2_0_0/SemuxApiTest.java
@@ -64,7 +64,6 @@ import java.util.stream.Collectors;
 
 import javax.ws.rs.BadRequestException;
 
-import org.apache.commons.lang3.RandomUtils;
 import org.junit.Test;
 import org.semux.TestUtils;
 import org.semux.api.v2_0_0.model.AddNodeResponse;


### PR DESCRIPTION
~~~ISO-8601 is a broadly supported date format by multiple languages. For example, in Javascript a `Date` object can be directly constructed using an ISO-8601 string, while the original format of `YYYY-MM-DD` isn't supported.~~~