### PR TITLE
GUI: Add transactions filtering

### DIFF
--- a/src/main/java/org/semux/gui/ComboBoxItem.java
+++ b/src/main/java/org/semux/gui/ComboBoxItem.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2017-2018 The Semux Developers
+ *
+ * Distributed under the MIT software license, see the accompanying file
+ * LICENSE or https://opensource.org/licenses/mit-license.php
+ */
+package org.semux.gui;
+
+public class ComboBoxItem<T> implements Comparable<ComboBoxItem<T>> {
+    private final String displayName;
+    private final T value;
+
+    public ComboBoxItem(String displayName, T value) {
+        this.displayName = displayName;
+        this.value = value;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public T getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return displayName;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+
+        ComboBoxItem<?> that = (ComboBoxItem<?>) o;
+
+        return displayName != null ? displayName.equals(that.displayName) : that.displayName == null;
+    }
+
+    @Override
+    public int hashCode() {
+        return displayName != null ? displayName.hashCode() : 0;
+    }
+
+    @Override
+    public int compareTo(ComboBoxItem<T> o) {
+        return displayName.compareTo(o.displayName);
+    }
+}

--- a/src/main/java/org/semux/gui/SwingUtil.java
+++ b/src/main/java/org/semux/gui/SwingUtil.java
@@ -563,7 +563,7 @@ public class SwingUtil {
      * @param address
      * @return
      */
-    private static String describeAddress(SemuxGui gui, byte[] address) {
+    public static String describeAddress(SemuxGui gui, byte[] address) {
         return getAddressAlias(gui, address)
                 .orElse(getAddressDelegateName(gui, address).orElse(getAddressAbbr(address)));
     }

--- a/src/main/java/org/semux/gui/panel/TransactionsPanel.java
+++ b/src/main/java/org/semux/gui/panel/TransactionsPanel.java
@@ -391,8 +391,7 @@ public class TransactionsPanel extends JPanel implements ActionListener {
         }
 
         // update filters that are not set for reduced filter set if filter not already
-        // set on them for
-        // further filtering
+        // set on them for further filtering
         if (to == null) {
             toModel.setData(allTo.stream()
                     .map(it -> new ComboBoxItem<>(SwingUtil.describeAddress(gui, it.getData()), it.getData()))

--- a/src/main/java/org/semux/gui/panel/TransactionsPanel.java
+++ b/src/main/java/org/semux/gui/panel/TransactionsPanel.java
@@ -288,8 +288,8 @@ public class TransactionsPanel extends JPanel implements ActionListener {
      */
     protected void refresh() {
         transactions.clear();
-        Set<byte[]> to = new HashSet<>();
-        Set<byte[]> from = new HashSet<>();
+        Set<ByteArray> to = new HashSet<>();
+        Set<ByteArray> from = new HashSet<>();
 
         // add pending transactions
         transactions.addAll(gui.getKernel().getPendingManager().getPendingTransactions()
@@ -328,8 +328,8 @@ public class TransactionsPanel extends JPanel implements ActionListener {
         // track all used addresses
         for (StatusTransaction statusTransaction : transactions) {
             Transaction transaction = statusTransaction.getTransaction();
-            to.add(transaction.getFrom());
-            from.add(transaction.getTo());
+            to.add(new ByteArray(transaction.getFrom()));
+            from.add(new ByteArray(transaction.getTo()));
         }
 
         // filter transactions
@@ -338,11 +338,11 @@ public class TransactionsPanel extends JPanel implements ActionListener {
         tableModel.setData(filteredTransactions);
 
         fromModel.setData(from.stream()
-                .map(it -> new ComboBoxItem<>(SwingUtil.describeAddress(gui, it), it))
+                .map(it -> new ComboBoxItem<>(SwingUtil.describeAddress(gui, it.getData()), it.getData()))
                 .collect(Collectors.toCollection(TreeSet::new)));
 
         toModel.setData(to.stream()
-                .map(it -> new ComboBoxItem<>(SwingUtil.describeAddress(gui, it), it))
+                .map(it -> new ComboBoxItem<>(SwingUtil.describeAddress(gui, it.getData()), it.getData()))
                 .collect(Collectors.toCollection(TreeSet::new)));
 
         if (tx != null) {

--- a/src/main/java/org/semux/gui/panel/TransactionsPanel.java
+++ b/src/main/java/org/semux/gui/panel/TransactionsPanel.java
@@ -107,6 +107,8 @@ public class TransactionsPanel extends JPanel implements ActionListener {
         JLabel to = new JLabel(GuiMessages.get("To"));
         JLabel from = new JLabel(GuiMessages.get("From"));
         JLabel type = new JLabel(GuiMessages.get("Type"));
+        JLabel amount = new JLabel(GuiMessages.get("Amount"));
+        JLabel separator = new JLabel("-");
 
         // create filter
         panelFilter = new TransactionsPanelFilter(gui, tableModel);
@@ -127,6 +129,14 @@ public class TransactionsPanel extends JPanel implements ActionListener {
                                 .addComponent(to)
                                 .addGap(10)
                                 .addComponent(panelFilter.getSelectTo(), GroupLayout.PREFERRED_SIZE, 210,
+                                        Short.MAX_VALUE)
+                                .addGap(10)
+                                .addComponent(amount)
+                                .addGap(10)
+                                .addComponent(panelFilter.getTxtMin(), GroupLayout.PREFERRED_SIZE, 60,
+                                        Short.MAX_VALUE)
+                                .addComponent(separator)
+                                .addComponent(panelFilter.getTxtMax(), GroupLayout.PREFERRED_SIZE, 60,
                                         Short.MAX_VALUE))
                         .addComponent(scrollPane));
         groupLayout.setVerticalGroup(
@@ -138,7 +148,12 @@ public class TransactionsPanel extends JPanel implements ActionListener {
                                         .addComponent(from)
                                         .addComponent(panelFilter.getSelectFrom())
                                         .addComponent(to)
-                                        .addComponent(panelFilter.getSelectTo())))
+                                        .addComponent(panelFilter.getSelectTo())
+                                        .addComponent(amount)
+                                        .addComponent(panelFilter.getTxtMin())
+                                        .addComponent(separator)
+                                        .addComponent(panelFilter.getTxtMax())
+                                        ))
                         .addGap(18)
                         .addComponent(scrollPane));
         setLayout(groupLayout);

--- a/src/main/java/org/semux/gui/panel/TransactionsPanel.java
+++ b/src/main/java/org/semux/gui/panel/TransactionsPanel.java
@@ -152,8 +152,7 @@ public class TransactionsPanel extends JPanel implements ActionListener {
                                         .addComponent(amount)
                                         .addComponent(panelFilter.getTxtMin())
                                         .addComponent(separator)
-                                        .addComponent(panelFilter.getTxtMax())
-                                        ))
+                                        .addComponent(panelFilter.getTxtMax())))
                         .addGap(18)
                         .addComponent(scrollPane));
         setLayout(groupLayout);

--- a/src/main/java/org/semux/gui/panel/TransactionsPanel.java
+++ b/src/main/java/org/semux/gui/panel/TransactionsPanel.java
@@ -66,11 +66,11 @@ public class TransactionsPanel extends JPanel implements ActionListener {
     private final TransactionsTableModel tableModel;
 
     private final JComboBox<ComboBoxItem<TransactionType>> selectType;
-    private final JComboBox<ComboBoxItem<ByteArray>> selectFrom;
-    private final JComboBox<ComboBoxItem<ByteArray>> selectTo;
+    private final JComboBox<ComboBoxItem<byte[]>> selectFrom;
+    private final JComboBox<ComboBoxItem<byte[]>> selectTo;
 
-    private final TransactionsComboBoxModel<ByteArray> fromModel;
-    private final TransactionsComboBoxModel<ByteArray> toModel;
+    private final TransactionsComboBoxModel<byte[]> fromModel;
+    private final TransactionsComboBoxModel<byte[]> toModel;
     private final TransactionsComboBoxModel<TransactionType> typeModel;
 
     public TransactionsPanel(SemuxGui gui, JFrame frame) {
@@ -276,8 +276,8 @@ public class TransactionsPanel extends JPanel implements ActionListener {
      */
     protected void refresh() {
         transactions.clear();
-        Set<ByteArray> to = new HashSet<>();
-        Set<ByteArray> from = new HashSet<>();
+        Set<byte[]> to = new HashSet<>();
+        Set<byte[]> from = new HashSet<>();
 
         // add pending transactions
         transactions.addAll(gui.getKernel().getPendingManager().getPendingTransactions()
@@ -316,8 +316,8 @@ public class TransactionsPanel extends JPanel implements ActionListener {
         // track all used addresses
         for (StatusTransaction statusTransaction : transactions) {
             Transaction transaction = statusTransaction.getTransaction();
-            to.add(new ByteArray(transaction.getFrom()));
-            from.add(new ByteArray(transaction.getFrom()));
+            to.add(transaction.getFrom());
+            from.add(transaction.getFrom());
         }
 
         // filter transactions
@@ -326,11 +326,11 @@ public class TransactionsPanel extends JPanel implements ActionListener {
         tableModel.setData(filteredTransactions);
 
         fromModel.setData(from.stream()
-                .map(it -> new ComboBoxItem<>(SwingUtil.describeAddress(gui, it.getData()), it))
+                .map(it -> new ComboBoxItem<>(SwingUtil.describeAddress(gui, it), it))
                 .collect(Collectors.toCollection(TreeSet::new)));
 
         toModel.setData(to.stream()
-                .map(it -> new ComboBoxItem<>(SwingUtil.describeAddress(gui, it.getData()), it))
+                .map(it -> new ComboBoxItem<>(SwingUtil.describeAddress(gui, it), it))
                 .collect(Collectors.toCollection(TreeSet::new)));
 
         if (tx != null) {
@@ -353,8 +353,8 @@ public class TransactionsPanel extends JPanel implements ActionListener {
     private List<StatusTransaction> filterTransactions(List<StatusTransaction> transactions) {
         List<StatusTransaction> filtered = new ArrayList<>();
         TransactionType type = typeModel.getSelectedValue();
-        ByteArray to = toModel.getSelectedValue();
-        ByteArray from = fromModel.getSelectedValue();
+        byte[] to = toModel.getSelectedValue();
+        byte[] from = fromModel.getSelectedValue();
 
         // add if not filtered out
         for (StatusTransaction transaction : transactions) {
@@ -362,16 +362,17 @@ public class TransactionsPanel extends JPanel implements ActionListener {
                 continue;
             }
 
-            if (to != null && !Arrays.equals(to.getData(), transaction.getTransaction().getTo())) {
+            if (to != null && !Arrays.equals(to, transaction.getTransaction().getTo())) {
                 continue;
             }
 
-            if (from != null && !Arrays.equals(from.getData(), transaction.getTransaction().getFrom())) {
+            if (from != null && !Arrays.equals(from, transaction.getTransaction().getFrom())) {
                 continue;
             }
 
             filtered.add(transaction);
         }
+
         return filtered;
     }
 

--- a/src/main/java/org/semux/gui/panel/TransactionsPanel.java
+++ b/src/main/java/org/semux/gui/panel/TransactionsPanel.java
@@ -6,16 +6,31 @@
  */
 package org.semux.gui.panel;
 
-import java.awt.*;
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Point;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
 import java.util.stream.Collectors;
 
-import javax.swing.*;
+import javax.swing.DefaultComboBoxModel;
+import javax.swing.GroupLayout;
+import javax.swing.JComboBox;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JTable;
 import javax.swing.border.LineBorder;
 import javax.swing.table.AbstractTableModel;
 import javax.swing.table.TableModel;

--- a/src/main/java/org/semux/gui/panel/TransactionsPanel.java
+++ b/src/main/java/org/semux/gui/panel/TransactionsPanel.java
@@ -323,7 +323,7 @@ public class TransactionsPanel extends JPanel implements ActionListener {
         for (StatusTransaction statusTransaction : transactions) {
             Transaction transaction = statusTransaction.getTransaction();
             to.add(transaction.getFrom());
-            from.add(transaction.getFrom());
+            from.add(transaction.getTo());
         }
 
         // filter transactions

--- a/src/main/java/org/semux/gui/panel/TransactionsPanel.java
+++ b/src/main/java/org/semux/gui/panel/TransactionsPanel.java
@@ -368,8 +368,8 @@ public class TransactionsPanel extends JPanel implements ActionListener {
         byte[] to = toModel.getSelectedValue();
         byte[] from = fromModel.getSelectedValue();
 
-        Set<byte[]> allTo = new HashSet<>();
-        Set<byte[]> allFrom = new HashSet<>();
+        Set<ByteArray> allTo = new HashSet<>();
+        Set<ByteArray> allFrom = new HashSet<>();
 
         // add if not filtered out
         for (StatusTransaction transaction : transactions) {
@@ -386,8 +386,8 @@ public class TransactionsPanel extends JPanel implements ActionListener {
             }
 
             filtered.add(transaction);
-            allTo.add(transaction.getTransaction().getTo());
-            allFrom.add(transaction.getTransaction().getFrom());
+            allTo.add(new ByteArray(transaction.getTransaction().getTo()));
+            allFrom.add(new ByteArray(transaction.getTransaction().getFrom()));
         }
 
         // update filters that are not set for reduced filter set if filter not already
@@ -395,13 +395,13 @@ public class TransactionsPanel extends JPanel implements ActionListener {
         // further filtering
         if (to == null) {
             toModel.setData(allTo.stream()
-                    .map(it -> new ComboBoxItem<>(SwingUtil.describeAddress(gui, it), it))
+                    .map(it -> new ComboBoxItem<>(SwingUtil.describeAddress(gui, it.getData()), it.getData()))
                     .collect(Collectors.toCollection(TreeSet::new)));
         }
 
         if (from == null) {
             fromModel.setData(allFrom.stream()
-                    .map(it -> new ComboBoxItem<>(SwingUtil.describeAddress(gui, it), it))
+                    .map(it -> new ComboBoxItem<>(SwingUtil.describeAddress(gui, it.getData()), it.getData()))
                     .collect(Collectors.toCollection(TreeSet::new)));
         }
 

--- a/src/main/java/org/semux/gui/panel/TransactionsPanel.java
+++ b/src/main/java/org/semux/gui/panel/TransactionsPanel.java
@@ -136,10 +136,15 @@ public class TransactionsPanel extends JPanel implements ActionListener {
                 groupLayout.createParallelGroup(GroupLayout.Alignment.TRAILING).addGroup(
                         groupLayout.createSequentialGroup()
                                 .addComponent(type)
+                                .addGap(10)
                                 .addComponent(selectType)
+                                .addGap(10)
                                 .addComponent(from)
+                                .addGap(10)
                                 .addComponent(selectFrom)
+                                .addGap(10)
                                 .addComponent(to)
+                                .addGap(10)
                                 .addComponent(selectTo))
                         .addComponent(scrollPane));
         groupLayout.setVerticalGroup(
@@ -152,6 +157,7 @@ public class TransactionsPanel extends JPanel implements ActionListener {
                                         .addComponent(selectFrom)
                                         .addComponent(to)
                                         .addComponent(selectTo)))
+                        .addGap(18)
                         .addComponent(scrollPane));
         setLayout(groupLayout);
 

--- a/src/main/java/org/semux/gui/panel/TransactionsPanelFilter.java
+++ b/src/main/java/org/semux/gui/panel/TransactionsPanelFilter.java
@@ -97,13 +97,11 @@ public class TransactionsPanelFilter {
                 continue;
             }
 
-            if(min != null && transaction.getTransaction().getValue().lt(min))
-            {
+            if (min != null && transaction.getTransaction().getValue().lt(min)) {
                 continue;
             }
 
-            if(max != null && transaction.getTransaction().getValue().gt(max))
-            {
+            if (max != null && transaction.getTransaction().getValue().gt(max)) {
                 continue;
             }
 
@@ -143,7 +141,7 @@ public class TransactionsPanelFilter {
         try {
             return SwingUtil.parseAmount(txtField.getText());
         } catch (ParseException e) {
-            logger.debug("Unable to parse amount for {}", txtField.getText() );
+            logger.debug("Unable to parse amount for {}", txtField.getText());
         }
 
         return null;

--- a/src/main/java/org/semux/gui/panel/TransactionsPanelFilter.java
+++ b/src/main/java/org/semux/gui/panel/TransactionsPanelFilter.java
@@ -1,0 +1,179 @@
+/**
+ * Copyright (c) 2017-2018 The Semux Developers
+ *
+ * Distributed under the MIT software license, see the accompanying file
+ * LICENSE or https://opensource.org/licenses/mit-license.php
+ */
+package org.semux.gui.panel;
+
+import org.semux.core.TransactionType;
+import org.semux.gui.ComboBoxItem;
+import org.semux.gui.SemuxGui;
+import org.semux.gui.SwingUtil;
+import org.semux.util.ByteArray;
+
+import javax.swing.DefaultComboBoxModel;
+import javax.swing.JComboBox;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+
+public class TransactionsPanelFilter {
+
+    private transient final SemuxGui gui;
+
+    private final JComboBox<ComboBoxItem<TransactionType>> selectType;
+    private final JComboBox<ComboBoxItem<byte[]>> selectFrom;
+    private final JComboBox<ComboBoxItem<byte[]>> selectTo;
+
+    private final TransactionsComboBoxModel<byte[]> fromModel;
+    private final TransactionsComboBoxModel<byte[]> toModel;
+    private final TransactionsComboBoxModel<TransactionType> typeModel;
+
+    private final TransactionsPanel.TransactionsTableModel tableModel;
+
+    private transient List<TransactionsPanel.StatusTransaction> transactions = new ArrayList<>();
+
+    public TransactionsPanelFilter(SemuxGui gui, TransactionsPanel.TransactionsTableModel tableModel) {
+        this.gui = gui;
+        this.tableModel = tableModel;
+
+        toModel = new TransactionsComboBoxModel<>();
+        fromModel = new TransactionsComboBoxModel<>();
+        typeModel = new TransactionsComboBoxModel<>();
+        typeModel.setData(Arrays.stream(TransactionType.values()).map(it -> new ComboBoxItem<>(it.toString(), it))
+                .collect(Collectors.toSet()));
+
+        selectType = new JComboBox<>(typeModel);
+        selectFrom = new JComboBox<>(fromModel);
+        selectTo = new JComboBox<>(toModel);
+    }
+
+    /**
+     * Filter transactions if filters are selected
+     *
+     * @return filtered transactions
+     */
+    public List<TransactionsPanel.StatusTransaction> getFilteredTransactions() {
+        List<TransactionsPanel.StatusTransaction> filtered = new ArrayList<>();
+        TransactionType type = typeModel.getSelectedValue();
+        byte[] to = toModel.getSelectedValue();
+        byte[] from = fromModel.getSelectedValue();
+        TransactionType transactionType = typeModel.getSelectedValue();
+
+        Set<ByteArray> allTo = new HashSet<>();
+        Set<ByteArray> allFrom = new HashSet<>();
+        Set<TransactionType> allTransactionType = new HashSet<>();
+
+        // add if not filtered out
+        for (TransactionsPanel.StatusTransaction transaction : transactions) {
+            if (type != null && !transaction.getTransaction().getType().equals(type)) {
+                continue;
+            }
+
+            if (to != null && !Arrays.equals(to, transaction.getTransaction().getTo())) {
+                continue;
+            }
+
+            if (from != null && !Arrays.equals(from, transaction.getTransaction().getFrom())) {
+                continue;
+            }
+
+            filtered.add(transaction);
+            allTo.add(new ByteArray(transaction.getTransaction().getTo()));
+            allFrom.add(new ByteArray(transaction.getTransaction().getFrom()));
+            allTransactionType.add(transaction.getTransaction().getType());
+        }
+
+        // update filters that are not set for reduced filter set if filter not already
+        // set on them for further filtering
+        if (to == null) {
+            toModel.setData(allTo.stream()
+                    .map(it -> new ComboBoxItem<>(SwingUtil.describeAddress(gui, it.getData()), it.getData()))
+                    .collect(Collectors.toCollection(TreeSet::new)));
+        }
+
+        if (from == null) {
+            fromModel.setData(allFrom.stream()
+                    .map(it -> new ComboBoxItem<>(SwingUtil.describeAddress(gui, it.getData()), it.getData()))
+                    .collect(Collectors.toCollection(TreeSet::new)));
+        }
+
+        if (transactionType == null) {
+            typeModel.setData(allTransactionType.stream()
+                    .map(it -> new ComboBoxItem<>(it.toString(), it))
+                    .collect(Collectors.toCollection(TreeSet::new)));
+        }
+
+        return filtered;
+    }
+
+    public JComboBox<ComboBoxItem<TransactionType>> getSelectType() {
+        return selectType;
+    }
+
+    public JComboBox<ComboBoxItem<byte[]>> getSelectFrom() {
+        return selectFrom;
+    }
+
+    public JComboBox<ComboBoxItem<byte[]>> getSelectTo() {
+        return selectTo;
+    }
+
+    public void setTransactions(List<TransactionsPanel.StatusTransaction> transactions) {
+        this.transactions = transactions;
+    }
+
+    class TransactionsComboBoxModel<T> extends DefaultComboBoxModel<ComboBoxItem<T>> {
+
+        private final ComboBoxItem<T> defaultItem;
+        private final Set<ComboBoxItem<T>> currentValues = new TreeSet<>();
+
+        public TransactionsComboBoxModel() {
+            this.defaultItem = new ComboBoxItem<>("", null);
+        }
+
+        public synchronized void setData(Set<ComboBoxItem<T>> values) {
+
+            // don't re-render the list if there are no changes
+            // avoids undesirable refreshing of a list user might be interacting with
+            if (currentValues.containsAll(values) && values.containsAll(currentValues)) {
+                return;
+            }
+
+            currentValues.clear();
+            currentValues.addAll(values);
+
+            Object selected = getSelectedItem();
+            removeAllElements();
+            addElement(defaultItem);
+            for (ComboBoxItem<T> value : currentValues) {
+                addElement(value);
+            }
+            setSelectedItem(selected);
+        }
+
+        @Override
+        public void setSelectedItem(Object anObject) {
+            // only refresh if new object selected
+            T existing = getSelectedValue();
+            T newValue = (T) (anObject instanceof ComboBoxItem ? ((ComboBoxItem) anObject).getValue() : anObject);
+            if (existing != newValue || existing == null || !existing.equals(newValue)) {
+                super.setSelectedItem(anObject);
+                List<TransactionsPanel.StatusTransaction> filteredTransactions = getFilteredTransactions();
+                tableModel.setData(filteredTransactions);
+            }
+
+        }
+
+        T getSelectedValue() {
+            ComboBoxItem<T> selected = (ComboBoxItem<T>) getSelectedItem();
+            return selected != null ? selected.getValue() : null;
+        }
+    }
+
+}


### PR DESCRIPTION
It's very difficult to locate a given transaction currently,
particularly for pool operators or heavy usage users.

Add filterable dropdowns to transactions panel.

fixes #550