### PR TITLE
CLI: Don't dump private key on create

### DIFF
--- a/src/main/java/org/semux/cli/SemuxCli.java
+++ b/src/main/java/org/semux/cli/SemuxCli.java
@@ -208,7 +208,6 @@ public class SemuxCli extends Launcher {
         if (wallet.flush()) {
             logger.info(CliMessages.get("NewAccountCreatedForAddress", key.toAddressString()));
             logger.info(CliMessages.get("PublicKey", Hex.encode(key.getPublicKey())));
-            logger.info(CliMessages.get("PrivateKey", Hex.encode(key.getPrivateKey())));
         }
     }
 

--- a/src/test/java/org/semux/cli/SemuxCliTest.java
+++ b/src/test/java/org/semux/cli/SemuxCliTest.java
@@ -371,7 +371,6 @@ public class SemuxCliTest {
         List<LogEvent> logs = TestLoggingAppender.events();
         assertThat(logs, hasItem(info(CliMessages.get("NewAccountCreatedForAddress", newAccount.toAddressString()))));
         assertThat(logs, hasItem(info(CliMessages.get("PublicKey", Hex.encode(newAccount.getPublicKey())))));
-        assertThat(logs, hasItem(info(CliMessages.get("PrivateKey", Hex.encode(newAccount.getPrivateKey())))));
     }
 
     @Test


### PR DESCRIPTION
If user desires privateKey, they can use the dumpPrivateKey command

Avoid logging to file the private key.  I had considered moving to
System.out.println, but we cannot guarentee order, seems safer to allow
user to choose whether public key gets logged (they can just use the
dump command if they need it)

fixes #863 