### PR TITLE
API: add 'GET /syncing' endpoint

### DIFF
--- a/src/main/java/org/semux/api/v2_0_0/impl/SemuxApiServiceImpl.java
+++ b/src/main/java/org/semux/api/v2_0_0/impl/SemuxApiServiceImpl.java
@@ -46,6 +46,7 @@ import org.semux.api.v2_0_0.model.GetLatestBlockResponse;
 import org.semux.api.v2_0_0.model.GetPeersResponse;
 import org.semux.api.v2_0_0.model.GetPendingTransactionsResponse;
 import org.semux.api.v2_0_0.model.GetRootResponse;
+import org.semux.api.v2_0_0.model.GetSyncingProgressResponse;
 import org.semux.api.v2_0_0.model.GetTransactionLimitsResponse;
 import org.semux.api.v2_0_0.model.GetTransactionResponse;
 import org.semux.api.v2_0_0.model.GetValidatorsResponse;
@@ -54,11 +55,13 @@ import org.semux.api.v2_0_0.model.GetVotesResponse;
 import org.semux.api.v2_0_0.model.ListAccountsResponse;
 import org.semux.api.v2_0_0.model.SignMessageResponse;
 import org.semux.api.v2_0_0.model.SignRawTransactionResponse;
+import org.semux.api.v2_0_0.model.SyncingProgressType;
 import org.semux.api.v2_0_0.model.VerifyMessageResponse;
 import org.semux.core.Block;
 import org.semux.core.Blockchain;
 import org.semux.core.BlockchainImpl;
 import org.semux.core.PendingManager;
+import org.semux.core.SyncManager;
 import org.semux.core.Transaction;
 import org.semux.core.TransactionType;
 import org.semux.core.exception.WalletLockedException;
@@ -742,6 +745,26 @@ public final class SemuxApiServiceImpl implements SemuxApi {
     @Override
     public Response vote(String from, String to, String value, String fee) {
         return doTransaction(TransactionType.VOTE, from, to, value, fee, null);
+    }
+
+    @Override
+    public Response getSyncingProgress() {
+        GetSyncingProgressResponse resp = new GetSyncingProgressResponse();
+        SyncingProgressType result = new SyncingProgressType();
+
+        if (kernel.getSyncManager().isRunning()) {
+            SyncManager.Progress progress = kernel.getSyncManager().getProgress();
+            result.setSyncing(true);
+            result.setStartingHeight(String.valueOf(progress.getStartingHeight()));
+            result.setCurrentHeight(String.valueOf(progress.getCurrentHeight()));
+            result.setTargetHeight(String.valueOf(progress.getTargetHeight()));
+        } else {
+            result.setSyncing(false);
+        }
+
+        resp.setSuccess(true);
+        resp.setResult(result);
+        return Response.ok(resp).build();
     }
 
     public Response failure(ApiHandlerResponse resp, String message) {

--- a/src/main/java/org/semux/consensus/SemuxSync.java
+++ b/src/main/java/org/semux/consensus/SemuxSync.java
@@ -492,7 +492,7 @@ public class SemuxSync implements SyncManager {
 
     public static class SemuxSyncProgress implements SyncManager.Progress {
 
-        final long beginHeight;
+        final long startingHeight;
 
         final long currentHeight;
 
@@ -500,16 +500,16 @@ public class SemuxSync implements SyncManager {
 
         final Duration duration;
 
-        public SemuxSyncProgress(long beginHeight, long currentHeight, long targetHeight, Duration duration) {
-            this.beginHeight = beginHeight;
+        public SemuxSyncProgress(long startingHeight, long currentHeight, long targetHeight, Duration duration) {
+            this.startingHeight = startingHeight;
             this.currentHeight = currentHeight;
             this.targetHeight = targetHeight;
             this.duration = duration;
         }
 
         @Override
-        public long getBeginHeight() {
-            return beginHeight;
+        public long getStartingHeight() {
+            return startingHeight;
         }
 
         @Override
@@ -536,7 +536,7 @@ public class SemuxSync implements SyncManager {
         }
 
         private Long getSpeed() {
-            Long downloadedBlocks = currentHeight - beginHeight;
+            Long downloadedBlocks = currentHeight - startingHeight;
             if (downloadedBlocks <= 0 || duration.toMillis() == 0) {
                 return null;
             }

--- a/src/main/java/org/semux/core/SyncManager.java
+++ b/src/main/java/org/semux/core/SyncManager.java
@@ -56,9 +56,9 @@ public interface SyncManager {
     interface Progress {
 
         /**
-         * @return the beginning height of this sync process.
+         * @return the starting height of this sync process.
          */
-        long getBeginHeight();
+        long getStartingHeight();
 
         /**
          * @return the current height of sync process.

--- a/src/main/resources/org/semux/api/v2_0_0/swagger.json
+++ b/src/main/resources/org/semux/api/v2_0_0/swagger.json
@@ -1362,6 +1362,33 @@
                     }
                 ]
             }
+        },
+        "/syncing" : {
+            "get" : {
+                "tags" : [
+                    "semux"
+                ],
+                "summary" : "Get syncing progress",
+                "description" : "Returns an object with data about the sync status",
+                "operationId" : "getSyncingProgress",
+                "produces" : [
+                    "application/json"
+                ],
+                "parameters" : [],
+                "responses" : {
+                    "200" : {
+                        "description" : "An object about the current sync status",
+                        "schema" : {
+                            "$ref" : "#/definitions/GetSyncingProgressResponse"
+                        }
+                    }
+                },
+                "security" : [
+                    {
+                        "basicAuth" : [ ]
+                    }
+                ]
+            }
         }
     },
     "definitions" : {
@@ -2206,6 +2233,55 @@
                     }
                 }
             ]
+        },
+        "GetSyncingProgressResponse" : {
+            "type" : "object",
+            "allOf": [
+                {
+                    "$ref" : "#/definitions/ApiHandlerResponse"
+                },
+                {
+                    "required" : [
+                        "result"
+                    ],
+                    "properties" : {
+                        "result" : {
+                            "type" : "object",
+                            "$ref" : "#/definitions/SyncingProgressType"
+                        }
+                    }
+                }
+            ]
+        },
+        "SyncingProgressType" : {
+            "type" : "object",
+            "required": [
+                "syncing"
+            ],
+            "properties" : {
+                "syncing" : {
+                    "description": "Whether the node is syncing",
+                    "type": "boolean"
+                },
+                "startingHeight" : {
+                    "description": "The block height at which the sync started",
+                    "type": "string",
+                    "format": "int64",
+                    "pattern": "^\\d+$"
+                },
+                "currentHeight" : {
+                    "description": "The current block height",
+                    "type" : "string",
+                    "format": "int64",
+                    "pattern": "^\\d+$"
+                },
+                "targetHeight" : {
+                    "description": "The target block height",
+                    "type": "string",
+                    "format" : "int64",
+                    "pattern": "^\\d+$"
+                }
+            }
         }
     }
 }

--- a/src/test/java/org/semux/gui/SemuxGuiTest.java
+++ b/src/test/java/org/semux/gui/SemuxGuiTest.java
@@ -120,7 +120,7 @@ public class SemuxGuiTest {
         assertThat(model.getTotalLocked()).isEqualTo(ZERO);
         assertThat(model.getActivePeers().size()).isEqualTo(channelMgr.getActivePeers().size());
         assertThat(model.getSyncProgress().get()).isEqualToComparingOnlyGivenFields(syncMgr.getProgress(),
-                "beginHeight",
+                "startingHeight",
                 "currentHeight", "targetHeight");
     }
 


### PR DESCRIPTION
This API allows consumers to retrieve current sync status programmatically