### PR TITLE
GUI: Don't update dropdowns if user is interacting

### DIFF
--- a/src/main/java/org/semux/gui/panel/DelegatesPanel.java
+++ b/src/main/java/org/semux/gui/panel/DelegatesPanel.java
@@ -385,18 +385,20 @@ public class DelegatesPanel extends JPanel implements ActionListener {
         // record selected account
         AccountItem selected = (AccountItem) selectFrom.getSelectedItem();
 
-        // update account list
-        selectFrom.removeAllItems();
-        for (WalletAccount aList : list) {
-            selectFrom.addItem(new AccountItem(aList));
-        }
+        // update account list if user is not interacting with it
+        if (!selectFrom.isPopupVisible()) {
+            selectFrom.removeAllItems();
+            for (WalletAccount aList : list) {
+                selectFrom.addItem(new AccountItem(aList));
+            }
 
-        // recover selected account
-        if (selected != null) {
-            for (int i = 0; i < list.size(); i++) {
-                if (Arrays.equals(list.get(i).getAddress(), selected.account.getAddress())) {
-                    selectFrom.setSelectedIndex(i);
-                    break;
+            // recover selected account
+            if (selected != null) {
+                for (int i = 0; i < list.size(); i++) {
+                    if (Arrays.equals(list.get(i).getAddress(), selected.account.getAddress())) {
+                        selectFrom.setSelectedIndex(i);
+                        break;
+                    }
                 }
             }
         }

--- a/src/main/java/org/semux/gui/panel/SendPanel.java
+++ b/src/main/java/org/semux/gui/panel/SendPanel.java
@@ -296,18 +296,20 @@ public class SendPanel extends JPanel implements ActionListener {
         // record selected account
         AccountItem selected = (AccountItem) selectFrom.getSelectedItem();
 
-        // update account list
-        selectFrom.removeAllItems();
-        for (WalletAccount aList : list) {
-            selectFrom.addItem(new AccountItem(aList));
-        }
+        // update account list if user is not interacting with it
+        if (!selectFrom.isPopupVisible()) {
+            selectFrom.removeAllItems();
+            for (WalletAccount aList : list) {
+                selectFrom.addItem(new AccountItem(aList));
+            }
 
-        // recover selected account
-        if (selected != null) {
-            for (int i = 0; i < list.size(); i++) {
-                if (Arrays.equals(list.get(i).getAddress(), selected.account.getAddress())) {
-                    selectFrom.setSelectedIndex(i);
-                    break;
+            // recover selected account
+            if (selected != null) {
+                for (int i = 0; i < list.size(); i++) {
+                    if (Arrays.equals(list.get(i).getAddress(), selected.account.getAddress())) {
+                        selectFrom.setSelectedIndex(i);
+                        break;
+                    }
                 }
             }
         }


### PR DESCRIPTION
If we update select boxes while user is interacting with it,
It re-renders the page and loses context/state of scrolling.

This is annoying for users.  If they are interacting with
the box, we have high confidence that data is not changing
elsewhere, or it can wait until next refresh.