### PR TITLE
API: Add Optional 'nonce' and 'validateNonce' Parameters to Transaction Ops of API 2.1

### DIFF
--- a/src/main/java/org/semux/api/ApiHandlerImpl.java
+++ b/src/main/java/org/semux/api/ApiHandlerImpl.java
@@ -144,10 +144,6 @@ public class ApiHandlerImpl implements ApiHandler {
                             return Boolean.parseBoolean(param);
                         }
 
-                        if (p.getRight().equals(Integer.class)) {
-                            return Integer.parseInt(param);
-                        }
-
                         return param;
                     }).toArray());
         }

--- a/src/main/java/org/semux/api/v2_1_0/impl/SemuxApiServiceImpl.java
+++ b/src/main/java/org/semux/api/v2_1_0/impl/SemuxApiServiceImpl.java
@@ -591,12 +591,12 @@ public final class SemuxApiServiceImpl implements SemuxApi, FailableApiService {
     }
 
     @Override
-    public Response registerDelegate(String from, String delegateName, String fee, String nonce) {
-        return doTransaction(TransactionType.DELEGATE, from, null, null, fee, nonce, delegateName);
+    public Response registerDelegate(String from, String data, String fee, String nonce, Boolean validateNonce) {
+        return doTransaction(TransactionType.DELEGATE, from, null, null, fee, nonce, validateNonce, data);
     }
 
     @Override
-    public Response broadcastRawTransaction(String raw) {
+    public Response broadcastRawTransaction(String raw, Boolean validateNonce) {
         DoTransactionResponse resp = new DoTransactionResponse();
 
         if (!isSet(raw)) {
@@ -608,7 +608,8 @@ public final class SemuxApiServiceImpl implements SemuxApi, FailableApiService {
 
             // tx nonce is validated in advance to avoid silently pushing the tx into
             // delayed queue of pending manager
-            if (tx.getNonce() != kernel.getPendingManager().getNonce(tx.getFrom())) {
+            if ((validateNonce == null || validateNonce)
+                    && tx.getNonce() != kernel.getPendingManager().getNonce(tx.getFrom())) {
                 return failure(resp, "Invalid transaction nonce.");
             }
 
@@ -696,13 +697,14 @@ public final class SemuxApiServiceImpl implements SemuxApi, FailableApiService {
     }
 
     @Override
-    public Response transfer(String from, String to, String value, String fee, String nonce, String data) {
-        return doTransaction(TransactionType.TRANSFER, from, to, value, fee, nonce, data);
+    public Response transfer(String from, String to, String value, String fee, String nonce, Boolean validateNonce,
+            String data) {
+        return doTransaction(TransactionType.TRANSFER, from, to, value, fee, nonce, validateNonce, data);
     }
 
     @Override
-    public Response unvote(String from, String to, String value, String fee, String nonce) {
-        return doTransaction(TransactionType.UNVOTE, from, to, value, fee, nonce, null);
+    public Response unvote(String from, String to, String value, String fee, String nonce, Boolean validateNonce) {
+        return doTransaction(TransactionType.UNVOTE, from, to, value, fee, nonce, validateNonce, null);
     }
 
     @Override
@@ -746,8 +748,8 @@ public final class SemuxApiServiceImpl implements SemuxApi, FailableApiService {
     }
 
     @Override
-    public Response vote(String from, String to, String value, String fee, String nonce) {
-        return doTransaction(TransactionType.VOTE, from, to, value, fee, nonce, null);
+    public Response vote(String from, String to, String value, String fee, String nonce, Boolean validateNonce) {
+        return doTransaction(TransactionType.VOTE, from, to, value, fee, nonce, validateNonce, null);
     }
 
     @Override
@@ -816,7 +818,7 @@ public final class SemuxApiServiceImpl implements SemuxApi, FailableApiService {
     }
 
     private Response doTransaction(TransactionType type, String from, String to, String value, String fee, String nonce,
-            String data) {
+            Boolean validateNonce, String data) {
         DoTransactionResponse resp = new DoTransactionResponse();
         try {
             TransactionBuilder transactionBuilder = new TransactionBuilder(kernel)
@@ -835,7 +837,8 @@ public final class SemuxApiServiceImpl implements SemuxApi, FailableApiService {
 
             // tx nonce is validated in advance to avoid silently pushing the tx into
             // delayed queue of pending manager
-            if (tx.getNonce() != kernel.getPendingManager().getNonce(tx.getFrom())) {
+            if ((validateNonce == null || validateNonce)
+                    && tx.getNonce() != kernel.getPendingManager().getNonce(tx.getFrom())) {
                 return failure(resp, "Invalid transaction nonce.");
             }
 

--- a/src/main/java/org/semux/api/v2_1_0/impl/SemuxApiServiceImpl.java
+++ b/src/main/java/org/semux/api/v2_1_0/impl/SemuxApiServiceImpl.java
@@ -832,6 +832,13 @@ public final class SemuxApiServiceImpl implements SemuxApi, FailableApiService {
             }
 
             Transaction tx = transactionBuilder.buildSigned();
+
+            // tx nonce is validated in advance to avoid silently pushing the tx into
+            // delayed queue of pending manager
+            if (tx.getNonce() != kernel.getPendingManager().getNonce(tx.getFrom())) {
+                return failure(resp, "Invalid transaction nonce.");
+            }
+
             PendingManager.ProcessTransactionResult result = kernel.getPendingManager().addTransactionSync(tx);
             if (result.error != null) {
                 return failure(resp, "Transaction rejected by pending manager: " + result.error.toString());

--- a/src/main/java/org/semux/api/v2_1_0/impl/SemuxApiServiceImpl.java
+++ b/src/main/java/org/semux/api/v2_1_0/impl/SemuxApiServiceImpl.java
@@ -608,7 +608,7 @@ public final class SemuxApiServiceImpl implements SemuxApi, FailableApiService {
 
             // tx nonce is validated in advance to avoid silently pushing the tx into
             // delayed queue of pending manager
-            if ((validateNonce == null || validateNonce)
+            if ((validateNonce != null && validateNonce)
                     && tx.getNonce() != kernel.getPendingManager().getNonce(tx.getFrom())) {
                 return failure(resp, "Invalid transaction nonce.");
             }
@@ -837,7 +837,7 @@ public final class SemuxApiServiceImpl implements SemuxApi, FailableApiService {
 
             // tx nonce is validated in advance to avoid silently pushing the tx into
             // delayed queue of pending manager
-            if ((validateNonce == null || validateNonce)
+            if ((validateNonce != null && validateNonce)
                     && tx.getNonce() != kernel.getPendingManager().getNonce(tx.getFrom())) {
                 return failure(resp, "Invalid transaction nonce.");
             }

--- a/src/main/java/org/semux/api/v2_1_0/impl/SemuxApiServiceImpl.java
+++ b/src/main/java/org/semux/api/v2_1_0/impl/SemuxApiServiceImpl.java
@@ -831,6 +831,8 @@ public final class SemuxApiServiceImpl implements SemuxApi, FailableApiService {
 
             if (nonce != null) {
                 transactionBuilder.withNonce(nonce);
+            } else {
+                // TODO: fix race condition of auto-assigned nonce
             }
 
             Transaction tx = transactionBuilder.buildSigned();

--- a/src/main/java/org/semux/core/PendingManager.java
+++ b/src/main/java/org/semux/core/PendingManager.java
@@ -308,6 +308,12 @@ public class PendingManager implements Runnable, BlockchainListener {
             return new ProcessTransactionResult(0, TransactionResult.Error.INVALID_TIMESTAMP);
         }
 
+        // report INVALID_NONCE error to prevent the transaction from being silently
+        // ignored due to a low nonce
+        if (tx.getNonce() < getNonce(tx.getFrom())) {
+            return new ProcessTransactionResult(0, TransactionResult.Error.INVALID_NONCE);
+        }
+
         // Check transaction nonce: pending transactions must be executed sequentially
         // by nonce in ascending order. In case of a nonce jump, the transaction is
         // delayed for the next event loop of PendingManager.

--- a/src/main/resources/org/semux/api/v2_1_0/swagger.html
+++ b/src/main/resources/org/semux/api/v2_1_0/swagger.html
@@ -3,7 +3,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>Semux API v2.0.0 Swagger UI</title>
+    <title>Semux API v2.1.0 Swagger UI</title>
     <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,700|Source+Code+Pro:300,600|Titillium+Web:400,600,700" rel="stylesheet">
     <link rel="stylesheet" type="text/css" href="/swagger-ui/swagger-ui.css" >
     <link rel="icon" type="image/png" href="/favicon-32x32.png" sizes="32x32" />

--- a/src/main/resources/org/semux/api/v2_1_0/swagger.json
+++ b/src/main/resources/org/semux/api/v2_1_0/swagger.json
@@ -977,6 +977,15 @@
                         "pattern" : "^\\d+$"
                     },
                     {
+                        "name" : "nonce",
+                        "in" : "query",
+                        "description" : "Transaction nonce",
+                        "required" : false,
+                        "type" : "string",
+                        "format" : "int64",
+                        "pattern" : "^\\d+$"
+                    },
+                    {
                         "name" : "data",
                         "in" : "query",
                         "description" : "Transaction data encoded in hexadecimal string",
@@ -1045,6 +1054,15 @@
                         "type" : "string",
                         "format" : "int64",
                         "pattern" : "^\\d+$"
+                    },
+                    {
+                        "name" : "nonce",
+                        "in" : "query",
+                        "description" : "Transaction nonce",
+                        "required" : false,
+                        "type" : "string",
+                        "format" : "int64",
+                        "pattern" : "^\\d+$"
                     }
                 ],
                 "responses" : {
@@ -1107,6 +1125,15 @@
                         "type" : "string",
                         "format" : "int64",
                         "pattern" : "^\\d+$"
+                    },
+                    {
+                        "name" : "nonce",
+                        "in" : "query",
+                        "description" : "Transaction nonce",
+                        "required" : false,
+                        "type" : "string",
+                        "format" : "int64",
+                        "pattern" : "^\\d+$"
                     }
                 ],
                 "responses" : {
@@ -1145,6 +1172,14 @@
                         "pattern" : "^(0x)?[0-9a-fA-F]{40}$"
                     },
                     {
+                        "name" : "data",
+                        "in" : "query",
+                        "description" : "Delegate name in hexadecimal encoded UTF-8 string, 16 bytes of data at maximum",
+                        "required" : true,
+                        "type" : "string",
+                        "pattern" : "^(0x)?[0-9a-fA-F]+$"
+                    },
+                    {
                         "name" : "fee",
                         "in" : "query",
                         "description" : "Transaction fee in nano SEM, default to minimum fee if omitted",
@@ -1154,12 +1189,13 @@
                         "pattern" : "^\\d+$"
                     },
                     {
-                        "name" : "data",
+                        "name" : "nonce",
                         "in" : "query",
-                        "description" : "Delegate name in hexadecimal encoded UTF-8 string, 16 bytes of data at maximum",
-                        "required" : true,
+                        "description" : "Transaction nonce",
+                        "required" : false,
                         "type" : "string",
-                        "pattern" : "^(0x)?[0-9a-fA-F]+$"
+                        "format" : "int64",
+                        "pattern" : "^\\d+$"
                     }
                 ],
                 "responses" : {

--- a/src/main/resources/org/semux/api/v2_1_0/swagger.json
+++ b/src/main/resources/org/semux/api/v2_1_0/swagger.json
@@ -986,6 +986,14 @@
                         "pattern" : "^\\d+$"
                     },
                     {
+                        "name" : "validateNonce",
+                        "in" : "query",
+                        "description" : "Whether validate tx nonce against the current account state, default to true if omitted",
+                        "required" : false,
+                        "default" : true,
+                        "type" : "boolean"
+                    },
+                    {
                         "name" : "data",
                         "in" : "query",
                         "description" : "Transaction data encoded in hexadecimal string",
@@ -1063,6 +1071,14 @@
                         "type" : "string",
                         "format" : "int64",
                         "pattern" : "^\\d+$"
+                    },
+                    {
+                        "name" : "validateNonce",
+                        "in" : "query",
+                        "description" : "Whether validate tx nonce against the current account state, default to true if omitted",
+                        "required" : false,
+                        "default" : true,
+                        "type" : "boolean"
                     }
                 ],
                 "responses" : {
@@ -1134,6 +1150,14 @@
                         "type" : "string",
                         "format" : "int64",
                         "pattern" : "^\\d+$"
+                    },
+                    {
+                        "name" : "validateNonce",
+                        "in" : "query",
+                        "description" : "Whether validate tx nonce against the current account state, default to true if omitted",
+                        "required" : false,
+                        "default" : true,
+                        "type" : "boolean"
                     }
                 ],
                 "responses" : {
@@ -1196,6 +1220,14 @@
                         "type" : "string",
                         "format" : "int64",
                         "pattern" : "^\\d+$"
+                    },
+                    {
+                        "name" : "validateNonce",
+                        "in" : "query",
+                        "description" : "Whether validate tx nonce against the current account state, default to true if omitted",
+                        "required" : false,
+                        "default" : true,
+                        "type" : "boolean"
                     }
                 ],
                 "responses" : {
@@ -1232,6 +1264,14 @@
                         "required" : true,
                         "type" : "string",
                         "pattern" : "^(0x)?[0-9a-fA-F]+$"
+                    },
+                    {
+                        "name" : "validateNonce",
+                        "in" : "query",
+                        "description" : "Whether to validate tx nonce against the current account state, default to true if omitted",
+                        "required" : false,
+                        "default" : true,
+                        "type" : "boolean"
                     }
                 ],
                 "responses" : {

--- a/src/main/resources/org/semux/api/v2_1_0/swagger.json
+++ b/src/main/resources/org/semux/api/v2_1_0/swagger.json
@@ -1228,7 +1228,7 @@
                     {
                         "name" : "raw",
                         "in" : "query",
-                        "description" : "Raw transaction",
+                        "description" : "Raw transaction encoded in hexadecimal string.",
                         "required" : true,
                         "type" : "string",
                         "pattern" : "^(0x)?[0-9a-fA-F]+$"

--- a/src/main/resources/org/semux/api/v2_1_0/swagger.json
+++ b/src/main/resources/org/semux/api/v2_1_0/swagger.json
@@ -988,9 +988,9 @@
                     {
                         "name" : "validateNonce",
                         "in" : "query",
-                        "description" : "Whether validate tx nonce against the current account state, default to true if omitted",
+                        "description" : "Whether validate tx nonce against the current account state, default to false if omitted",
                         "required" : false,
-                        "default" : true,
+                        "default" : false,
                         "type" : "boolean"
                     },
                     {
@@ -1075,9 +1075,9 @@
                     {
                         "name" : "validateNonce",
                         "in" : "query",
-                        "description" : "Whether validate tx nonce against the current account state, default to true if omitted",
+                        "description" : "Whether validate tx nonce against the current account state, default to false if omitted",
                         "required" : false,
-                        "default" : true,
+                        "default" : false,
                         "type" : "boolean"
                     }
                 ],
@@ -1154,9 +1154,9 @@
                     {
                         "name" : "validateNonce",
                         "in" : "query",
-                        "description" : "Whether validate tx nonce against the current account state, default to true if omitted",
+                        "description" : "Whether validate tx nonce against the current account state, default to false if omitted",
                         "required" : false,
-                        "default" : true,
+                        "default" : false,
                         "type" : "boolean"
                     }
                 ],
@@ -1224,9 +1224,9 @@
                     {
                         "name" : "validateNonce",
                         "in" : "query",
-                        "description" : "Whether validate tx nonce against the current account state, default to true if omitted",
+                        "description" : "Whether validate tx nonce against the current account state, default to false if omitted",
                         "required" : false,
-                        "default" : true,
+                        "default" : false,
                         "type" : "boolean"
                     }
                 ],
@@ -1268,9 +1268,9 @@
                     {
                         "name" : "validateNonce",
                         "in" : "query",
-                        "description" : "Whether to validate tx nonce against the current account state, default to true if omitted",
+                        "description" : "Whether to validate tx nonce against the current account state, default to false if omitted",
                         "required" : false,
-                        "default" : true,
+                        "default" : false,
                         "type" : "boolean"
                     }
                 ],

--- a/src/main/resources/org/semux/api/v2_1_0/swagger.json
+++ b/src/main/resources/org/semux/api/v2_1_0/swagger.json
@@ -979,7 +979,7 @@
                     {
                         "name" : "nonce",
                         "in" : "query",
-                        "description" : "Transaction nonce",
+                        "description" : "Transaction nonce, default to sender's nonce if omitted",
                         "required" : false,
                         "type" : "string",
                         "format" : "int64",
@@ -1058,7 +1058,7 @@
                     {
                         "name" : "nonce",
                         "in" : "query",
-                        "description" : "Transaction nonce",
+                        "description" : "Transaction nonce, default to sender's nonce if omitted",
                         "required" : false,
                         "type" : "string",
                         "format" : "int64",
@@ -1129,7 +1129,7 @@
                     {
                         "name" : "nonce",
                         "in" : "query",
-                        "description" : "Transaction nonce",
+                        "description" : "Transaction nonce, default to sender's nonce if omitted",
                         "required" : false,
                         "type" : "string",
                         "format" : "int64",
@@ -1191,7 +1191,7 @@
                     {
                         "name" : "nonce",
                         "in" : "query",
-                        "description" : "Transaction nonce",
+                        "description" : "Transaction nonce, default to sender's nonce if omitted",
                         "required" : false,
                         "type" : "string",
                         "format" : "int64",

--- a/src/test/java/org/semux/TestUtils.java
+++ b/src/test/java/org/semux/TestUtils.java
@@ -49,10 +49,13 @@ public class TestUtils {
     }
 
     public static Transaction createTransaction(Config config, Key from, Key to, Amount value) {
+        return createTransaction(config, from, to, value, 0);
+    }
+
+    public static Transaction createTransaction(Config config, Key from, Key to, Amount value, long nonce) {
         Network network = config.network();
         TransactionType type = TransactionType.TRANSFER;
         Amount fee = config.minTransactionFee();
-        long nonce = 0;
         long timestamp = System.currentTimeMillis();
         byte[] data = {};
 

--- a/src/test/java/org/semux/api/v1_0_1/ApiHandlerTest.java
+++ b/src/test/java/org/semux/api/v1_0_1/ApiHandlerTest.java
@@ -83,6 +83,7 @@ import net.bytebuddy.utility.RandomString;
 /**
  * @deprecated
  */
+@SuppressWarnings("Duplicates")
 public class ApiHandlerTest extends ApiHandlerTestBase {
 
     @Rule

--- a/src/test/java/org/semux/api/v2_0_0/SemuxApiTest.java
+++ b/src/test/java/org/semux/api/v2_0_0/SemuxApiTest.java
@@ -112,6 +112,7 @@ import io.netty.handler.ipfilter.IpFilterRuleType;
 /**
  * API tests for {@link org.semux.api.v2_0_0.impl.SemuxApiServiceImpl}
  */
+@SuppressWarnings("Duplicates")
 public class SemuxApiTest extends SemuxApiTestBase {
 
     @Test

--- a/src/test/java/org/semux/api/v2_1_0/SemuxApiTest.java
+++ b/src/test/java/org/semux/api/v2_1_0/SemuxApiTest.java
@@ -518,7 +518,7 @@ public class SemuxApiTest extends SemuxApiTestBase {
         String from = wallet.getAccount(0).toAddressString();
         String fee = String.valueOf(config.minTransactionFee().getNano());
         String data = Hex.encode(Bytes.of("test_delegate"));
-        DoTransactionResponse response = api.registerDelegate(from, data, fee, null);
+        DoTransactionResponse response = api.registerDelegate(from, data, fee, null, null);
         assertNotNull(response);
         assertTrue(response.isSuccess());
         assertNotNull(response.getResult());
@@ -540,7 +540,7 @@ public class SemuxApiTest extends SemuxApiTestBase {
                 config.minTransactionFee());
         Transaction tx = createTransaction(config, from, to, value);
 
-        DoTransactionResponse response = api.broadcastRawTransaction(Hex.encode(tx.toBytes()));
+        DoTransactionResponse response = api.broadcastRawTransaction(Hex.encode(tx.toBytes()), null);
         assertTrue(response.isSuccess());
 
         Thread.sleep(200);
@@ -563,7 +563,25 @@ public class SemuxApiTest extends SemuxApiTestBase {
         kernelRule.getKernel().setPendingManager(pendingManager);
 
         Transaction tx = createTransaction(config, from, to, value);
-        api.broadcastRawTransaction(Hex.encode(tx.toBytes()));
+        api.broadcastRawTransaction(Hex.encode(tx.toBytes()), null);
+    }
+
+    @Test
+    public void broadcastRawTransactionInvalidNonceWithValidateNonceFalseTest() {
+        Key from = new Key();
+        Key to = new Key();
+        Amount value = Amount.ZERO;
+
+        // mock state
+        kernelRule.getKernel().getBlockchain().getAccountState().adjustAvailable(from.toAddress(),
+                config.minTransactionFee());
+        PendingManager pendingManager = spy(pendingMgr);
+        when(pendingManager.getNonce(from.toAddress())).thenReturn(100L);
+        kernelRule.getKernel().setPendingManager(pendingManager);
+
+        Transaction tx = createTransaction(config, from, to, value);
+        DoTransactionResponse resp = api.broadcastRawTransaction(Hex.encode(tx.toBytes()), false);
+        assertTrue(resp.isSuccess());
     }
 
     @Test
@@ -598,9 +616,10 @@ public class SemuxApiTest extends SemuxApiTestBase {
         String to = key.toAddressString();
         String fee = "5432100";
         String nonce = null;
+        Boolean validateNonce = null;
         String data = Hex.encode(Bytes.of("test_transfer"));
 
-        DoTransactionResponse response = api.transfer(from, to, value, fee, nonce, data);
+        DoTransactionResponse response = api.transfer(from, to, value, fee, nonce, validateNonce, data);
         assertNotNull(response);
         assertTrue(response.isSuccess());
         assertNotNull(response.getResult());
@@ -624,9 +643,10 @@ public class SemuxApiTest extends SemuxApiTestBase {
         String to = key.toAddressString();
         String fee = "5432100";
         String nonce = "999";
+        Boolean validateNonce = null;
         String data = null;
 
-        api.transfer(from, to, value, fee, nonce, data);
+        api.transfer(from, to, value, fee, nonce, validateNonce, data);
     }
 
     @Test
@@ -636,7 +656,7 @@ public class SemuxApiTest extends SemuxApiTestBase {
         String from = wallet.getAccount(0).toAddressString();
         String to = key.toAddressString();
 
-        DoTransactionResponse response = api.transfer(from, to, value, null, null, null);
+        DoTransactionResponse response = api.transfer(from, to, value, null, null, null, null);
         assertNotNull(response);
         assertTrue(response.isSuccess());
         assertNotNull(response.getResult());
@@ -666,7 +686,7 @@ public class SemuxApiTest extends SemuxApiTestBase {
         String value = String.valueOf(amount.getNano());
         String fee = "50000000";
 
-        DoTransactionResponse response = api.unvote(from, to, value, fee, null);
+        DoTransactionResponse response = api.unvote(from, to, value, fee, null, null);
         assertNotNull(response);
 
         assertTrue(response.isSuccess());
@@ -695,7 +715,7 @@ public class SemuxApiTest extends SemuxApiTestBase {
         String value = String.valueOf(amount.getNano());
         String fee = String.valueOf(config.minTransactionFee().getNano());
 
-        DoTransactionResponse response = api.vote(from, to, value, fee, null);
+        DoTransactionResponse response = api.vote(from, to, value, fee, null, null);
         assertTrue(response.isSuccess());
         assertNotNull(response.getResult());
 

--- a/src/test/java/org/semux/api/v2_1_0/SemuxApiTest.java
+++ b/src/test/java/org/semux/api/v2_1_0/SemuxApiTest.java
@@ -616,6 +616,19 @@ public class SemuxApiTest extends SemuxApiTestBase {
         assertEquals(data, Hex.encode(tx.getData()));
     }
 
+    @Test(expected = BadRequestException.class)
+    public void transferWithInvalidNonceTest() {
+        Key key = new Key();
+        String value = "1000000000";
+        String from = wallet.getAccount(0).toAddressString();
+        String to = key.toAddressString();
+        String fee = "5432100";
+        String nonce = "999";
+        String data = null;
+
+        api.transfer(from, to, value, fee, nonce, data);
+    }
+
     @Test
     public void transferDefaultFeeTest() throws InterruptedException {
         Key key = new Key();

--- a/src/test/java/org/semux/api/v2_1_0/SemuxApiTest.java
+++ b/src/test/java/org/semux/api/v2_1_0/SemuxApiTest.java
@@ -122,6 +122,7 @@ import io.netty.handler.ipfilter.IpFilterRuleType;
 /**
  * API tests for {@link org.semux.api.v2_1_0.impl.SemuxApiServiceImpl}
  */
+@SuppressWarnings("Duplicates")
 public class SemuxApiTest extends SemuxApiTestBase {
 
     @Test
@@ -517,7 +518,7 @@ public class SemuxApiTest extends SemuxApiTestBase {
         String from = wallet.getAccount(0).toAddressString();
         String fee = String.valueOf(config.minTransactionFee().getNano());
         String data = Hex.encode(Bytes.of("test_delegate"));
-        DoTransactionResponse response = api.registerDelegate(from, data, fee);
+        DoTransactionResponse response = api.registerDelegate(from, data, fee, null);
         assertNotNull(response);
         assertTrue(response.isSuccess());
         assertNotNull(response.getResult());
@@ -598,7 +599,7 @@ public class SemuxApiTest extends SemuxApiTestBase {
         String fee = "5432100";
         String data = Hex.encode(Bytes.of("test_transfer"));
 
-        DoTransactionResponse response = api.transfer(from, to, value, fee, data);
+        DoTransactionResponse response = api.transfer(from, to, value, fee, data, null);
         assertNotNull(response);
         assertTrue(response.isSuccess());
         assertNotNull(response.getResult());
@@ -621,7 +622,7 @@ public class SemuxApiTest extends SemuxApiTestBase {
         String from = wallet.getAccount(0).toAddressString();
         String to = key.toAddressString();
 
-        DoTransactionResponse response = api.transfer(from, to, value, null, null);
+        DoTransactionResponse response = api.transfer(from, to, value, null, null, null);
         assertNotNull(response);
         assertTrue(response.isSuccess());
         assertNotNull(response.getResult());
@@ -651,7 +652,7 @@ public class SemuxApiTest extends SemuxApiTestBase {
         String value = String.valueOf(amount.getNano());
         String fee = "50000000";
 
-        DoTransactionResponse response = api.unvote(from, to, value, fee);
+        DoTransactionResponse response = api.unvote(from, to, value, fee, null);
         assertNotNull(response);
 
         assertTrue(response.isSuccess());
@@ -680,7 +681,7 @@ public class SemuxApiTest extends SemuxApiTestBase {
         String value = String.valueOf(amount.getNano());
         String fee = String.valueOf(config.minTransactionFee().getNano());
 
-        DoTransactionResponse response = api.vote(from, to, value, fee);
+        DoTransactionResponse response = api.vote(from, to, value, fee, null);
         assertTrue(response.isSuccess());
         assertNotNull(response.getResult());
 

--- a/src/test/java/org/semux/api/v2_1_0/SemuxApiTest.java
+++ b/src/test/java/org/semux/api/v2_1_0/SemuxApiTest.java
@@ -550,7 +550,7 @@ public class SemuxApiTest extends SemuxApiTestBase {
     }
 
     @Test(expected = BadRequestException.class)
-    public void broadcastRawTransactionInvalidNonceTest() {
+    public void broadcastRawTransactionValidateNonceTest() {
         Key from = new Key();
         Key to = new Key();
         Amount value = Amount.ZERO;
@@ -562,12 +562,12 @@ public class SemuxApiTest extends SemuxApiTestBase {
         when(pendingManager.getNonce(from.toAddress())).thenReturn(100L);
         kernelRule.getKernel().setPendingManager(pendingManager);
 
-        Transaction tx = createTransaction(config, from, to, value);
-        api.broadcastRawTransaction(Hex.encode(tx.toBytes()), null);
+        Transaction tx = createTransaction(config, from, to, value, 101L);
+        api.broadcastRawTransaction(Hex.encode(tx.toBytes()), true);
     }
 
     @Test
-    public void broadcastRawTransactionInvalidNonceWithValidateNonceFalseTest() {
+    public void broadcastRawTransactionNoValidateNonceTest() {
         Key from = new Key();
         Key to = new Key();
         Amount value = Amount.ZERO;
@@ -579,7 +579,7 @@ public class SemuxApiTest extends SemuxApiTestBase {
         when(pendingManager.getNonce(from.toAddress())).thenReturn(100L);
         kernelRule.getKernel().setPendingManager(pendingManager);
 
-        Transaction tx = createTransaction(config, from, to, value);
+        Transaction tx = createTransaction(config, from, to, value, 101L);
         DoTransactionResponse resp = api.broadcastRawTransaction(Hex.encode(tx.toBytes()), false);
         assertTrue(resp.isSuccess());
     }
@@ -635,8 +635,8 @@ public class SemuxApiTest extends SemuxApiTestBase {
         assertEquals(data, Hex.encode(tx.getData()));
     }
 
-    @Test(expected = BadRequestException.class)
-    public void transferWithInvalidNonceTest() {
+    @Test
+    public void transferWithHighNonceTest() {
         Key key = new Key();
         String value = "1000000000";
         String from = wallet.getAccount(0).toAddressString();
@@ -644,6 +644,21 @@ public class SemuxApiTest extends SemuxApiTestBase {
         String fee = "5432100";
         String nonce = "999";
         Boolean validateNonce = null;
+        String data = null;
+
+        DoTransactionResponse resp = api.transfer(from, to, value, fee, nonce, validateNonce, data);
+        assertTrue(resp.isSuccess());
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void transferValidateNonceTest() {
+        Key key = new Key();
+        String value = "1000000000";
+        String from = wallet.getAccount(0).toAddressString();
+        String to = key.toAddressString();
+        String fee = "5432100";
+        String nonce = "999";
+        Boolean validateNonce = true;
         String data = null;
 
         api.transfer(from, to, value, fee, nonce, validateNonce, data);

--- a/src/test/java/org/semux/api/v2_1_0/SemuxApiTest.java
+++ b/src/test/java/org/semux/api/v2_1_0/SemuxApiTest.java
@@ -597,9 +597,10 @@ public class SemuxApiTest extends SemuxApiTestBase {
         String from = wallet.getAccount(0).toAddressString();
         String to = key.toAddressString();
         String fee = "5432100";
+        String nonce = null;
         String data = Hex.encode(Bytes.of("test_transfer"));
 
-        DoTransactionResponse response = api.transfer(from, to, value, fee, data, null);
+        DoTransactionResponse response = api.transfer(from, to, value, fee, nonce, data);
         assertNotNull(response);
         assertTrue(response.isSuccess());
         assertNotNull(response.getResult());


### PR DESCRIPTION
fix #880 

- [x] add `nonce` parameter, default to the current sender's nonce if omitted
- [x] add `validateNonce` parameter, default to true if omitted 