### PR TITLE
API: Add Delete Account and Import Private Key Features

### DIFF
--- a/src/main/java/org/semux/api/v2_1_0/impl/SemuxApiServiceImpl.java
+++ b/src/main/java/org/semux/api/v2_1_0/impl/SemuxApiServiceImpl.java
@@ -13,6 +13,7 @@ import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 import java.io.File;
 import java.net.UnknownHostException;
 import java.nio.charset.Charset;
+import java.security.spec.InvalidKeySpecException;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
@@ -165,12 +166,20 @@ public final class SemuxApiServiceImpl implements SemuxApi, FailableApiService {
     }
 
     @Override
-    public Response createAccount(String name) {
+    public Response createAccount(String name, String privateKey) {
         CreateAccountResponse resp = new CreateAccountResponse();
         try {
-            // create an account
-            Key key = new Key();
-            kernel.getWallet().addAccount(key);
+            Key key;
+            if (privateKey != null) { // import
+                byte[] privateKeyBytes = Hex.decode0x(privateKey);
+                key = new Key(privateKeyBytes);
+            } else { // generate
+                key = new Key();
+            }
+
+            if (!kernel.getWallet().addAccount(key)) {
+                return failure(resp, "The key already exists in this wallet.");
+            }
 
             // set alias of the address
             if (isSet(name)) {
@@ -182,6 +191,10 @@ public final class SemuxApiServiceImpl implements SemuxApi, FailableApiService {
             resp.setResult(Hex.PREF + key.toAddressString());
             resp.setSuccess(true);
             return Response.ok().entity(resp).build();
+        } catch (CryptoException ex) {
+            return failure(resp, "Parameter `privateKey` is not a valid hexadecimal string");
+        } catch (InvalidKeySpecException e) {
+            return failure(resp, "Parameter `privateKey` is not a valid ED25519 private key encoded in PKCS#8 format");
         } catch (WalletLockedException e) {
             return failure(resp, e.getMessage());
         }

--- a/src/main/java/org/semux/core/Wallet.java
+++ b/src/main/java/org/semux/core/Wallet.java
@@ -418,10 +418,25 @@ public class Wallet {
      * 
      */
     public boolean removeAccount(Key key) throws WalletLockedException {
+        return removeAccount(key.toAddress());
+    }
+
+    /**
+     * Deletes an account in the wallet.
+     *
+     * NOTE: you need to call {@link #flush()} to update the wallet on disk.
+     *
+     * @param address
+     *            address bytes of the account to delete
+     * @return true if the account was successfully deleted, false otherwise
+     * @throws WalletLockedException
+     *
+     */
+    public boolean removeAccount(byte[] address) throws WalletLockedException {
         requireUnlocked();
 
         synchronized (accounts) {
-            return accounts.remove(ByteArray.of(key.toAddress())) != null;
+            return accounts.remove(ByteArray.of(address)) != null;
         }
     }
 

--- a/src/main/resources/org/semux/api/v2_1_0/swagger.json
+++ b/src/main/resources/org/semux/api/v2_1_0/swagger.json
@@ -226,6 +226,40 @@
                         "basicAuth" : [ ]
                     }
                 ]
+            },
+            "delete" : {
+                "tags": [
+                    "semux"
+                ],
+                "summary" : "Delete account",
+                "description" : "Deletes an account from this wallet.",
+                "operationId" : "deleteAccount",
+                "produces" : [
+                    "application/json"
+                ],
+                "parameters" : [
+                    {
+                        "name" : "address",
+                        "in" : "query",
+                        "description" : "Address of the account",
+                        "required" : true,
+                        "type" : "string",
+                        "pattern" : "^(0x)?[0-9a-fA-F]{40}$"
+                    }
+                ],
+                "responses" : {
+                    "200" : {
+                        "description" : "successful operation",
+                        "schema" : {
+                            "$ref" : "#/definitions/DeleteAccountResponse"
+                        }
+                    }
+                },
+                "security" : [
+                    {
+                        "basicAuth" : [ ]
+                    }
+                ]
             }
         },
         "/delegate" : {
@@ -1601,6 +1635,17 @@
                             "$ref" : "#/definitions/AccountType"
                         }
                     }
+                }
+            ]
+        },
+        "DeleteAccountResponse" : {
+            "type" : "object",
+            "required": [
+                "success"
+            ],
+            "allOf" : [
+                {
+                    "$ref" : "#/definitions/ApiHandlerResponse"
                 }
             ]
         },

--- a/src/main/resources/org/semux/api/v2_1_0/swagger.json
+++ b/src/main/resources/org/semux/api/v2_1_0/swagger.json
@@ -198,8 +198,8 @@
                 "tags": [
                     "semux"
                 ],
-                "summary" : "Create account",
-                "description" : "Creates a new account.",
+                "summary" : "Create or import an account",
+                "description" : "Creates a new account by generating a new private key or importing an existing private key when parameter 'privateKey' is provided.",
                 "operationId" : "createAccount",
                 "produces" : [
                     "application/json"
@@ -211,6 +211,14 @@
                         "description" : "Assigned alias to the created account.",
                         "required" : false,
                         "type" : "string"
+                    },
+                    {
+                        "name" : "privateKey",
+                        "in" : "query",
+                        "description" : "The private key to be imported, create a new key if omitted",
+                        "required" : false,
+                        "type" : "string",
+                        "pattern" : "^(0x)?[0-9a-fA-F]{96}$"
                     }
                 ],
                 "responses" : {

--- a/src/test/java/org/semux/api/v2_1_0/SemuxApiTest.java
+++ b/src/test/java/org/semux/api/v2_1_0/SemuxApiTest.java
@@ -174,9 +174,19 @@ public class SemuxApiTest extends SemuxApiTestBase {
     @Test
     public void createAccountTest() {
         int size = wallet.getAccounts().size();
-        CreateAccountResponse response = api.createAccount(null);
+        CreateAccountResponse response = api.createAccount(null, null);
         assertTrue(response.isSuccess());
         assertEquals(size + 1, wallet.getAccounts().size());
+    }
+
+    @Test
+    public void createAccountImportPrivateKeyTest() {
+        int size = wallet.getAccounts().size();
+        String privateKey = "302e020100300506032b657004220420acbd5f2cb2b6053f704376d12df99f2aa163d267a755c7f1d9fe55d2a2dc5405";
+        CreateAccountResponse response = api.createAccount(null, privateKey);
+        assertTrue(response.isSuccess());
+        assertEquals(size + 1, wallet.getAccounts().size());
+        assertEquals("23a6049381fd2cfb0661d9de206613b83d53d7df", wallet.getAccounts().get(size).toAddressString());
     }
 
     @Test

--- a/src/test/java/org/semux/api/v2_1_0/SemuxApiTest.java
+++ b/src/test/java/org/semux/api/v2_1_0/SemuxApiTest.java
@@ -72,6 +72,7 @@ import org.semux.api.v2_1_0.model.BlockType;
 import org.semux.api.v2_1_0.model.ComposeRawTransactionResponse;
 import org.semux.api.v2_1_0.model.CreateAccountResponse;
 import org.semux.api.v2_1_0.model.DelegateType;
+import org.semux.api.v2_1_0.model.DeleteAccountResponse;
 import org.semux.api.v2_1_0.model.DoTransactionResponse;
 import org.semux.api.v2_1_0.model.GetAccountPendingTransactionsResponse;
 import org.semux.api.v2_1_0.model.GetAccountResponse;
@@ -193,6 +194,14 @@ public class SemuxApiTest extends SemuxApiTestBase {
         assertTrue(response.isSuccess());
         assertEquals(SEM.of(1000).getNano(), Long.parseLong(response.getResult().getAvailable()));
         assertEquals(Integer.valueOf(1), response.getResult().getTransactionCount());
+    }
+
+    @Test
+    public void deleteAccountTest() {
+        Key account = wallet.getAccounts().get(0);
+        DeleteAccountResponse resp = api.deleteAccount(account.toAddressString());
+        assertTrue(resp.isSuccess());
+        assertThat(wallet.getAccounts()).doesNotContain(account);
     }
 
     @Test


### PR DESCRIPTION
fix #859 

- [x] Add `DELETE /account?address` endpoint
- [x] Add an optional 'privateKey' parameter to 'POST /account' endpoint 