### PR TITLE
Net: fix block header message constructors

### DIFF
--- a/src/main/java/org/semux/net/msg/consensus/BlockHeaderMessage.java
+++ b/src/main/java/org/semux/net/msg/consensus/BlockHeaderMessage.java
@@ -17,7 +17,7 @@ public class BlockHeaderMessage extends Message {
     private final BlockHeader header;
 
     public BlockHeaderMessage(BlockHeader header) {
-        super(MessageCode.GET_BLOCK_HEADER, null);
+        super(MessageCode.BLOCK_HEADER, null);
 
         this.header = header;
 
@@ -27,13 +27,12 @@ public class BlockHeaderMessage extends Message {
     }
 
     public BlockHeaderMessage(byte[] encoded) {
-        super(MessageCode.GET_BLOCK, null);
+        super(MessageCode.BLOCK_HEADER, null);
 
         this.encoded = encoded;
 
         SimpleDecoder dec = new SimpleDecoder(encoded);
-        byte[] bytes = dec.readBytes();
-        this.header = BlockHeader.fromBytes(bytes);
+        this.header = BlockHeader.fromBytes(dec.readBytes());
     }
 
     public BlockHeader getHeader() {

--- a/src/main/java/org/semux/net/msg/consensus/GetBlockHeaderMessage.java
+++ b/src/main/java/org/semux/net/msg/consensus/GetBlockHeaderMessage.java
@@ -15,7 +15,7 @@ public class GetBlockHeaderMessage extends Message {
     private final long number;
 
     public GetBlockHeaderMessage(long number) {
-        super(MessageCode.GET_BLOCK_HEADER, BlockMessage.class);
+        super(MessageCode.GET_BLOCK_HEADER, BlockHeaderMessage.class);
 
         this.number = number;
 
@@ -25,7 +25,7 @@ public class GetBlockHeaderMessage extends Message {
     }
 
     public GetBlockHeaderMessage(byte[] encoded) {
-        super(MessageCode.GET_BLOCK_HEADER, BlockMessage.class);
+        super(MessageCode.GET_BLOCK_HEADER, BlockHeaderMessage.class);
 
         this.encoded = encoded;
 

--- a/src/test/java/org/semux/net/msg/consensus/BlockHeaderMessageTest.java
+++ b/src/test/java/org/semux/net/msg/consensus/BlockHeaderMessageTest.java
@@ -13,6 +13,7 @@ import java.util.Collections;
 import org.junit.Test;
 import org.semux.core.BlockHeader;
 import org.semux.crypto.Key;
+import org.semux.net.msg.MessageCode;
 import org.semux.util.Bytes;
 import org.semux.util.MerkleUtil;
 
@@ -33,8 +34,12 @@ public class BlockHeaderMessageTest {
                 stateRoot, data);
 
         BlockHeaderMessage m = new BlockHeaderMessage(header);
-        BlockHeaderMessage m2 = new BlockHeaderMessage(m.getEncoded());
+        assertThat(m.getCode()).isEqualTo(MessageCode.BLOCK_HEADER);
+        assertThat(m.getResponseMessageClass()).isNull();
 
+        BlockHeaderMessage m2 = new BlockHeaderMessage(m.getEncoded());
+        assertThat(m2.getCode()).isEqualTo(MessageCode.BLOCK_HEADER);
+        assertThat(m2.getResponseMessageClass()).isNull();
         assertThat(m2.getHeader()).isEqualToComparingFieldByField(header);
     }
 }

--- a/src/test/java/org/semux/net/msg/consensus/GetBlockHeaderMessageTest.java
+++ b/src/test/java/org/semux/net/msg/consensus/GetBlockHeaderMessageTest.java
@@ -9,6 +9,7 @@ package org.semux.net.msg.consensus;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
+import org.semux.net.msg.MessageCode;
 
 public class GetBlockHeaderMessageTest {
 
@@ -17,8 +18,12 @@ public class GetBlockHeaderMessageTest {
         long number = 1;
 
         GetBlockHeaderMessage m = new GetBlockHeaderMessage(number);
-        GetBlockHeaderMessage m2 = new GetBlockHeaderMessage(m.getEncoded());
+        assertThat(m.getCode()).isEqualTo(MessageCode.GET_BLOCK_HEADER);
+        assertThat(m.getResponseMessageClass()).isEqualTo(BlockHeaderMessage.class);
 
+        GetBlockHeaderMessage m2 = new GetBlockHeaderMessage(m.getEncoded());
+        assertThat(m2.getCode()).isEqualTo(MessageCode.GET_BLOCK_HEADER);
+        assertThat(m2.getResponseMessageClass()).isEqualTo(BlockHeaderMessage.class);
         assertThat(m2.getNumber()).isEqualTo(number);
     }
 }


### PR DESCRIPTION
Reported by @kaar2 

- [x] Correct the message code of `BlockHeaderMessage` 
- [x] Correct the response class of `GetBlockHeaderMessage`