### PR TITLE
Sync speedup

### DIFF
--- a/src/main/java/org/semux/consensus/SemuxSync.java
+++ b/src/main/java/org/semux/consensus/SemuxSync.java
@@ -258,7 +258,8 @@ public class SemuxSync implements SyncManager {
             Long task = toDownload.first();
 
             // quit if too many pending blocks
-            if (toProcess.size() > MAX_PENDING_BLOCKS && task > toProcess.first().getKey().getNumber()) {
+            int pendingBlocks = toProcess.size() + currentSet.size() + toFinalize.size();
+            if (pendingBlocks > MAX_PENDING_BLOCKS && task > toProcess.first().getKey().getNumber()) {
                 logger.trace("Pending block queue is full");
                 return;
             }


### PR DESCRIPTION
Added faster sync. This new implementation basically does what was suggested here: in #803 with some modifications to handle invalid blocks. For each validator set, it first validates the votes for the last block, and then compares each block hash against it's child ParentHash field. If all block hashes are valid, they are added to the chain through validateApplyBlock method, while skipping the vote validation. If not all blocks in the validator sets have been forged, it will simply sync normally.

I did some benchmarks: in the original sync, the validateAndApply method was running in 28 miliseconds on average (~35 blocks per second), and in the new implementation it runs in 0.95 miliseconds on average (~1000 blocks per second). So the bottleneck is now in the download, and not in the validation (was able to sync ~340k blocks in ~35 mins, thats roughly 160 blocks per second, much less than the average speed of validateApplyBlock. 
Would be great if others could make benchmarks aswell, as I think it's possible to achieve even better results with a better connection than mine.