### PR TITLE
GUI: fix account ordering on select from account

### DIFF
--- a/src/main/java/org/semux/gui/panel/SendPanel.java
+++ b/src/main/java/org/semux/gui/panel/SendPanel.java
@@ -432,9 +432,11 @@ public class SendPanel extends JPanel implements ActionListener {
      */
     protected WalletAccount getSelectedAccount() {
         AccountItem selected = (AccountItem) selectFrom.getSelectedItem();
-        for (WalletAccount account : model.getAccounts()) {
-            if (selected != null && Arrays.equals(selected.address, account.getAddress())) {
-                return account;
+        if (selected != null) {
+            for (WalletAccount account : model.getAccounts()) {
+                if (Arrays.equals(selected.address, account.getAddress())) {
+                    return account;
+                }
             }
         }
 

--- a/src/main/java/org/semux/gui/panel/SendPanel.java
+++ b/src/main/java/org/semux/gui/panel/SendPanel.java
@@ -431,8 +431,14 @@ public class SendPanel extends JPanel implements ActionListener {
      * @return
      */
     protected WalletAccount getSelectedAccount() {
-        int idx = selectFrom.getSelectedIndex();
-        return (idx == -1) ? null : model.getAccounts().get(idx);
+        AccountItem selected = (AccountItem) selectFrom.getSelectedItem();
+        for (WalletAccount account : model.getAccounts()) {
+            if (selected != null && Arrays.equals(selected.address, account.getAddress())) {
+                return account;
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/src/main/java/org/semux/gui/panel/SendPanel.java
+++ b/src/main/java/org/semux/gui/panel/SendPanel.java
@@ -432,15 +432,12 @@ public class SendPanel extends JPanel implements ActionListener {
      */
     protected WalletAccount getSelectedAccount() {
         AccountItem selected = (AccountItem) selectFrom.getSelectedItem();
-        if (selected != null) {
-            for (WalletAccount account : model.getAccounts()) {
-                if (Arrays.equals(selected.address, account.getAddress())) {
-                    return account;
-                }
-            }
-        }
-
-        return null;
+        return selected == null ? null
+                : model.getAccounts()
+                        .stream()
+                        .filter(walletAccount -> Arrays.equals(selected.address, walletAccount.getAddress()))
+                        .findFirst()
+                        .orElse(null);
     }
 
     /**


### PR DESCRIPTION
Select account uses array ordering.
This fixes the 1.2.0 branch and should be considered and emergency fixpack

The RC will select the wrong account.